### PR TITLE
Fix typo in namespace

### DIFF
--- a/src/Mailer/Mail/ResettingMail.php
+++ b/src/Mailer/Mail/ResettingMail.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Nucleos\UserBundle\Mailer\Mai;
+namespace Nucleos\UserBundle\Mailer\Mail;
 
 use Nucleos\UserBundle\Model\UserInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Nucleos\UserBundle\Mailer;
 
-use Nucleos\UserBundle\Mailer\Mai\ResettingMail;
+use Nucleos\UserBundle\Mailer\Mail\ResettingMail;
 use Nucleos\UserBundle\Model\UserInterface;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\MailerInterface as SymfonyMailer;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->


## Subject

There was a typo in `Mail`
