### PR TITLE
Inject symfony mailer instead of swift mailer

### DIFF
--- a/src/Resources/config/mailer.xml
+++ b/src/Resources/config/mailer.xml
@@ -2,7 +2,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <services>
     <service id="nucleos_user.mailer.default" class="Nucleos\UserBundle\Mailer\Mailer" public="false">
-      <argument type="service" id="mailer"/>
+      <argument type="service" id="mailer.mailer"/>
       <argument type="service" id="translator"/>
       <argument type="service" id="router"/>
       <argument>%nucleos_user.resetting.from_email%</argument>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->



## Subject

The alias `mailer` refers to the old swift mailer
