### PR TITLE
Add documentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,6 @@ Makefile         export-ignore
 Jenkinsfile      export-ignore
 phpstan.neon     export-ignore
 phpunit.xml.dist export-ignore
+/docs            export-ignore
 /tests           export-ignore
 /vendor-bin      export-ignore

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,7 +12,7 @@ repository:
     allow_merge_commit: true
     allow_rebase_merge: true
     has_issues: true
-    has_pages: false
+    has_pages: true
     has_projects: false
     has_wiki: false
 
@@ -57,6 +57,7 @@ branches:
                     - "Code Coverage (7.4)"
                     - "Mutation Tests (7.4)"
                     - "Mutation Tests (7.4)"
+                    - "Lint / DOCtor-RST"
                 strict: true
 
             required_pull_request_reviews: null

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+on: [push, pull_request]
+
+name: Lint
+
+jobs:
+    doctor-rst:
+        name: DOCtor-RST
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
+            - name: DOCtor-RST
+              uses: docker://oskarstark/doctor-rst
+              with:
+                  args: --short
+              env:
+                  DOCS_DIR: 'docs/'

--- a/README.md
+++ b/README.md
@@ -26,3 +26,16 @@ Features included:
 
 - Users can be stored via Doctrine ORM or MongoDB ODM
 - Password reset support
+
+Documentation
+-------------
+
+The source of the documentation is stored in the `docs/` folder
+in this bundle.
+
+[Read the Documentation](docs/index.rst)
+
+Installation
+------------
+
+All the installation instructions are located in the documentation.

--- a/docs/.doctor-rst.yaml
+++ b/docs/.doctor-rst.yaml
@@ -1,0 +1,43 @@
+rules:
+    no_inheritdoc: ~
+    avoid_repetetive_words: ~
+    blank_line_after_directive: ~
+    short_array_syntax: ~
+    no_app_console: ~
+    typo: ~
+    replacement: ~
+    composer_dev_option_not_at_the_end: ~
+    yarn_dev_option_at_the_end: ~
+    versionadded_directive_should_have_version: ~
+    deprecated_directive_should_have_version: ~
+    no_composer_req: ~
+    no_php_open_tag_in_code_block_php_directive: ~
+    no_blank_line_after_filepath_in_php_code_block: ~
+    no_blank_line_after_filepath_in_yaml_code_block: ~
+    no_blank_line_after_filepath_in_xml_code_block: ~
+    no_blank_line_after_filepath_in_twig_code_block: ~
+    php_prefix_before_bin_console: ~
+    use_deprecated_directive_instead_of_versionadded: ~
+    no_space_before_self_xml_closing_tag: ~
+    no_explicit_use_of_code_block_php: ~
+    ensure_order_of_code_blocks_in_configuration_block: ~
+    american_english: ~
+    valid_use_statements: ~
+    lowercase_as_in_use_statements: ~
+    ordered_use_statements: ~
+    no_namespace_after_use_statements: ~
+    correct_code_block_directive_based_on_the_content: ~
+    max_blank_lines:
+        max: 2
+    replace_code_block_types: ~
+    use_https_xsd_urls: ~
+    blank_line_before_directive: ~
+    extension_xlf_instead_of_xliff: ~
+    valid_inline_highlighted_namespaces: ~
+    indention: ~
+    unused_links: ~
+    yaml_instead_of_yml_suffix: ~
+    extend_abstract_controller: ~
+
+# do not report as violation
+whitelist:

--- a/docs/canonicalizer.rst
+++ b/docs/canonicalizer.rst
@@ -1,0 +1,47 @@
+NucleosUserBundle Canonicalization
+==================================
+
+NucleosUserBundle stores canonicalized versions of the username and the email
+which are used when querying and checking for uniqueness.
+The default implementation makes them case-insensitive to avoid having
+users whose username only differs because of the case. It uses :phpfunction:`mb_convert_case`
+to achieve this result.
+
+.. caution::
+
+    If you do not have the mbstring extension installed you will need to
+    define your own canonicalizer.
+
+Replacing the canonicalizers
+----------------------------
+
+If you want to change the way the canonical fields are populated,
+create a class implementing ``Nucleos\UserBundle\Util\CanonicalizerInterface``
+and register it as a service:
+
+.. code-block:: yaml
+
+    # config/services.yaml
+    services:
+        app.my_canonicalizer:
+            class: App\Util\CustomCanonicalizer
+            public: false
+
+
+You can now configure NucleosUserBundle to use your own implementation:
+
+.. code-block:: yaml
+
+    # config/packages/nucleos_user.yaml
+    nucleos_user:
+        # ...
+        service:
+            email_canonicalizer:    app.my_canonicalizer
+            username_canonicalizer: app.my_canonicalizer
+
+You can of course use different services for each field if you don't want
+to use the same logic.
+
+.. note::
+
+    The default implementation has the id ``nucleos_user.util.canonicalizer.default``.

--- a/docs/command_line_tools.rst
+++ b/docs/command_line_tools.rst
@@ -1,0 +1,163 @@
+NucleosUserBundle Command Line Tools
+====================================
+
+The NucleosUserBundle provides a number of command line utilities to help manage your
+application's users. Commands are available for the following tasks:
+
+1. Create a User
+2. Activate a User
+3. Deactivate a User
+4. Promote a User
+5. Demote a User
+6. Change a User's Password
+
+.. note::
+
+    You must have correctly installed and configured the NucleosUserBundle before
+    using these commands.
+
+Create a User
+-------------
+
+You can use the ``nucleos:user:create`` command to create a new user for your application.
+The command takes three arguments, the ``username``, ``email``, and ``password`` for
+the user you are creating.
+
+For example if you wanted to create a user with username ``testuser``, with email
+``test@example.com`` and password ``p@ssword``, you would run the command as follows.
+
+.. code-block:: bash
+
+    $ php bin/console nucleos:user:create testuser test@example.com p@ssword
+
+If any of the required arguments are not passed to the command, an interactive prompt
+will ask you to enter them. For example, if you ran the command as follows, then
+you would be prompted to enter the ``email`` and ``password`` for the user
+you want to create.
+
+.. code-block:: bash
+
+    $ php bin/console nucleos:user:create testuser
+
+There are two options that you can pass to the command as well. They are
+``--super-admin`` and ``--inactive``.
+
+Specifying the ``--super-admin`` option will flag the user as a super admin when
+the user is created. A super admin has access to any part of your application.
+An example is provided below:
+
+.. code-block:: bash
+
+    $ php bin/console nucleos:user:create adminuser --super-admin
+
+If you specify the ``--inactive`` option, then the user that you create will no be
+able to log in until he is activated.
+
+.. code-block:: bash
+
+    $ php bin/console nucleos:user:create testuser --inactive
+
+Activate a User
+---------------
+
+The ``nucleos:user:activate`` command activates an inactive user. The only argument
+that the command requires is the ``username`` of the user who should be activated.
+If no ``username`` is specified then an interactive prompt will ask you
+to enter one. An example of using this command is listed below.
+
+.. code-block:: bash
+
+    $ php bin/console nucleos:user:activate testuser
+
+Deactivate a User
+-----------------
+
+The ``nucleos:user:deactivate`` command deactivates a user. Like the activate
+command, the only required argument is the ``username`` of the user who should be
+activated. If no ``username`` is specified then an interactive prompt will ask you
+to enter one. Below is an example of using this command.
+
+.. code-block:: bash
+
+    $ php bin/console nucleos:user:deactivate testuser
+
+Promote a User
+--------------
+
+The ``nucleos:user:promote`` command enables you to add a role to a user or make the
+user a super administrator.
+
+If you would like to add a role to a user you pass the ``username`` of the
+user as the first argument to the command and the ``role`` to add to the user as
+the second.
+
+.. code-block:: bash
+
+    $ php bin/console nucleos:user:promote testuser ROLE_ADMIN
+
+You can promote a user to a super administrator by passing the ``--super`` option
+after specifying the ``username``.
+
+.. code-block:: bash
+
+    $ php bin/console nucleos:user:promote testuser --super
+
+If any of the arguments to the command are not specified then an interactive
+prompt will ask you to enter them.
+
+.. note::
+
+    You may not specify the ``role`` argument and the ``--super`` option simultaneously.
+
+.. caution::
+
+    Changes will not be applied until the user logs out and back in again.
+
+Demote a User
+-------------
+
+The ``nucleos:user:demote`` command is similar to the promote command except that
+instead of adding a role to the user it removes it. You can also revoke a user's
+super administrator status with this command.
+
+If you would like to remove a role from a user you pass the ``username`` of
+the user as the first argument to the command and the ``role`` to remove as the
+second.
+
+.. code-block:: bash
+
+    $ php bin/console nucleos:user:demote testuser ROLE_ADMIN
+
+To revoke the super administrator status of a user, pass the ``username`` as
+an argument to the command as well as the ``--super`` option.
+
+.. code-block:: bash
+
+    $ php bin/console nucleos:user:demote testuser --super
+
+If any of the arguments to the command are not specified then an interactive
+prompt will ask you to enter them.
+
+.. note::
+
+    You may not specify the ``role`` argument and the ``--super`` option simultaneously.
+
+.. caution::
+
+    Changes will not be applied until the user logs out and back in again. This has
+    implications for the way in which you configure sessions in your application since
+    you want to ensure that users are demoted as quickly as possible.
+
+Change a User's Password
+------------------------
+
+The ``nucleos:user:change-password`` command provides an easy way to change a user's
+password. The command takes two arguments, the ``username`` of the user whose
+password you would like to change and the new ``password``.
+
+.. code-block:: bash
+
+    $ php bin/console nucleos:user:change-password testuser newp@ssword
+
+If you do not specify the ``password`` argument then an interactive prompt will
+ask you to enter one.

--- a/docs/configuration_reference.rst
+++ b/docs/configuration_reference.rst
@@ -1,0 +1,29 @@
+NucleosUserBundle Configuration Reference
+=========================================
+
+All available configuration options are listed below with their default values.
+
+.. code-block:: yaml
+
+    nucleos_user:
+        db_driver:              ~ # Required
+        firewall_name:          ~ # Required
+        user_class:             ~ # Required
+        use_listener:               true
+        use_flash_notifications:    true
+        model_manager_name:         null  # change it to the name of your entity/document manager if you don't want to use the default one.
+        use_authentication_listener: true
+        from_email:             webmaster@example.com
+        resetting:
+            retry_ttl: 7200 # Value in seconds, logic will use as hours
+            token_ttl: 86400
+            from_email: # Use this node only if you don't want the global email address for the resetting email
+        service:
+            mailer:                 nucleos_user.mailer.default
+            email_canonicalizer:    nucleos_user.util.canonicalizer.default
+            username_canonicalizer: nucleos_user.util.canonicalizer.default
+            token_generator:        nucleos_user.util.token_generator.default
+            user_manager:           nucleos_user.user_manager.default
+        group:
+            group_class:    ~ # Required when using groups
+            group_manager:  nucleos_user.group_manager.default

--- a/docs/controller_events.rst
+++ b/docs/controller_events.rst
@@ -1,0 +1,73 @@
+Hooking into the controllers
+============================
+
+The controllers packaged with the NucleosUserBundle provide a lot of
+functionality that is sufficient for general use cases. But, you might find
+that you need to extend that functionality and add some logic that suits the
+specific needs of your application.
+
+For this purpose, the controllers are dispatching events in many places in
+their logic. All events can be found in the constants of the
+``Nucleos\UserBundle\NucleosUserEvents`` class.
+
+All controllers follow the same convention: they dispatch a ``SUCCESS`` event
+when the form is valid before saving the user, and a ``COMPLETED`` event when
+it is done. Thus, all ``SUCCESS`` events allow you to set a response if you
+don't want the default redirection. And all ``COMPLETED`` events give you access
+to the response before it is returned.
+
+Controllers with a form also dispatch an ``INITIALIZE`` event after the entity is
+fetched, but before the form is created.
+
+For instance, this listener will change the redirection after the password
+resetting to go to the homepage::
+
+    // src/App/EventListener/PasswordResettingListener.php
+    namespace App\EventListener;
+
+    use Nucleos\UserBundle\Event\FormEvent;
+    use Nucleos\UserBundle\NucleosUserEvents;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+    use Symfony\Component\HttpFoundation\RedirectResponse;
+    use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+    /**
+     * Listener responsible to change the redirection at the end of the password resetting
+     */
+    class PasswordResettingListener implements EventSubscriberInterface
+    {
+        private $router;
+
+        public function __construct(UrlGeneratorInterface $router)
+        {
+            $this->router = $router;
+        }
+
+        public static function getSubscribedEvents(): array
+        {
+            return [
+                NucleosUserEvents::RESETTING_RESET_SUCCESS => 'onPasswordResettingSuccess',
+            ];
+        }
+
+        public function onPasswordResettingSuccess(FormEvent $event): void
+        {
+            $url = $this->router->generate('homepage');
+
+            $event->setResponse(new RedirectResponse($url));
+        }
+    }
+
+You can then register this listener:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/services.yaml
+        services:
+            app.password_resetting:
+                class: App\EventListener\PasswordResettingListener
+                arguments: ['@router']
+                tags:
+                    - { name: kernel.event_subscriber }

--- a/docs/custom_storage_layer.rst
+++ b/docs/custom_storage_layer.rst
@@ -1,0 +1,54 @@
+Using a custom storage layer
+============================
+
+NucleosUserBundle has been designed to allow you to change the storage
+layer used by your application and keep all of the functionality
+provided by the bundle.
+
+Implementing a new storage layer requires providing two classes: the user
+implementation and the corresponding user manager (you will of course need
+two other classes if you want to use the groups).
+
+The user implementation must implement ``Nucleos\UserBundle\Model\UserInterface``
+and the user manager must implement ``Nucleos\UserBundle\Model\UserManagerInterface``.
+The ``Nucleos\UserBundle\Model`` namespace provides base classes to make it easier to
+implement these interfaces.
+
+.. note::
+
+    You need to take care to always call ``updateCanonicalFields`` and ``updatePassword``
+    before saving a user. This is done when calling ``updateUser`` so you will
+    be safe if you always use the user manager to save the users.
+    If your storage layer gives you a hook in its saving process, you can use
+    it to make your implementation more flexible (this is done for Doctrine
+    using listeners for instance)
+
+Configuring NucleosUserBundle to use your implementation
+--------------------------------------------------------
+
+To use your own implementation, create a service for your user manager. The
+following example will assume that its id is ``app.custom_user_manager``.
+
+.. code-block:: yaml
+
+    # config/packages/nucleos_user.yaml
+    nucleos_user:
+        db_driver: custom  # custom means that none of the built-in implementation is used
+        user_class: App\Model\CustomUser
+        service:
+            user_manager: app.custom_user_manager
+        firewall_name: main
+
+.. note::
+
+    Your own service can be a private one. NucleosUserBundle will create an alias
+    to make it available through ``nucleos_user.user_manager``.
+
+.. caution::
+
+    The validation of the uniqueness of the username and email fields is done
+    using the constraints provided by DoctrineBundle. You will
+    need to take care of this validation when using a custom storage layer,
+    using a `custom constraint`_
+
+.. _custom constraint: https://symfony.com/doc/current/cookbook/validation/custom_constraint.html

--- a/docs/doctrine.rst
+++ b/docs/doctrine.rst
@@ -1,0 +1,45 @@
+More about Doctrine implementations
+===================================
+
+This chapter describes some things specific to these implementations.
+
+Using a different object manager than the default one
+-----------------------------------------------------
+
+Using the default configuration , NucleosUserBundle will use the default doctrine
+object manager. If you are using multiple ones and want to handle your users
+with a non-default one, you can change the object manager used in the configuration
+by giving its name to NucleosUserBundle.
+
+.. code-block:: yaml
+
+    # config/packages/nucleos_user.yaml
+    nucleos_user:
+        db_driver: orm
+        model_manager_name: non_default # the name of your entity manager
+
+.. note::
+
+    Using the default object manager is done by setting the configuration
+    option to ``null`` which is the default value.
+
+Replacing the mapping of the bundle
+-----------------------------------
+
+None of the Doctrine projects currently allow overwriting part of the mapping
+of a mapped superclass in the child entity.
+
+If you need to change the mapping (for instance to adapt the field names
+to a legacy database), one solution could be to write the whole mapping again
+without inheriting the mapping from the mapped superclass. In such case,
+your entity should extend directly from ``Nucleos\UserBundle\Model\User`` (and
+``Nucleos\UserBundle\Model\Group`` for the group). Another solution can be through
+`doctrine attribute and relations overrides`_.
+
+.. caution::
+
+    It is highly recommended to map all fields used by the bundle (see the
+    mapping files of the bundle in ``src/Resources/config/doctrine-mapping/``). Omitting
+    them can lead to unexpected behaviors and should be done carefully.
+
+.. _doctrine attribute and relations overrides: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/inheritance-mapping.html#overrides

--- a/docs/emails.rst
+++ b/docs/emails.rst
@@ -1,0 +1,97 @@
+NucleosUserBundle Emails
+========================
+
+The NucleosUserBundle has built-in support for sending emails in two different
+instances.
+
+Password Reset
+--------------
+
+An email is also sent when a user has requested a password reset. The
+NucleosUserBundle provides password reset functionality in a two-step process.
+First the user must request a password reset. After the request has been
+made, an email is sent containing a link to visit. Upon visiting the link,
+the user will be identified by the token contained in the url. When the user
+visits the link and the token is confirmed, the user will be presented with
+a form to enter in a new password.
+
+Default Mailer Implementations
+------------------------------
+
+The bundle comes with three mailer implementations. They are listed below
+by service id:
+
+- ``nucleos_user.mailer.default`` is the default implementation, and uses symfony mailer to send emails.
+- ``nucleos_user.mailer.noop`` is a mailer implementation which performs no operation, so no emails are sent.
+
+Configuring the Sender Email Address
+------------------------------------
+
+The NucleosUserBundle default mailer allows you to configure the sender email address
+of the emails sent out by the bundle. You can configure the address globally or on
+a per email basis.
+
+To configure the sender email address for all emails sent out by the bundle,
+update your ``nucleos_user`` config as follows:
+
+.. code-block:: yaml
+
+    # config/packages/nucleos_user.yaml
+    nucleos_user:
+        # ...
+        from_email:   noreply@example.com
+
+The bundle also provides the flexibility of allowing you to configure the sender
+email address for the emails individually.
+
+You can similarly update the ``nucleos_user`` config to change the sender email address for
+the password reset request email:
+
+.. code-block:: yaml
+
+    # config/packages/nucleos_user.yaml
+    nucleos_user:
+        # ...
+        resetting:
+            email:
+                from_email:   resetting@example.com
+
+Using A Custom Mailer
+---------------------
+
+The default mailer service used by NucleosUserBundle relies on the symfony mailer
+library to send mail. If you would like to use a different library to send
+emails or change the content of the email you
+may do so by defining your own service.
+
+First you must create a new class which implements ``Nucleos\UserBundle\Mailer\MailerInterface``
+which is listed below::
+
+    namespace Nucleos\UserBundle\Mailer;
+
+    use Nucleos\UserBundle\Model\UserInterface;
+
+    interface MailerInterface
+    {
+
+        /**
+         * Send an email to a user to confirm the password reset
+         *
+         * @param UserInterface $user
+         */
+        function sendResettingEmailMessage(UserInterface $user);
+    }
+
+After you have implemented your custom mailer class and defined it as a service,
+you must update your bundle configuration so that NucleosUserBundle will use it.
+Set the ``mailer`` configuration parameter under the ``service`` section.
+An example is listed below.
+
+.. code-block:: yaml
+
+    # config/packages/nucleos_user.yaml
+    nucleos_user:
+        # ...
+        service:
+            mailer: app.custom_nucleos_user_mailer
+

--- a/docs/groups.rst
+++ b/docs/groups.rst
@@ -1,0 +1,154 @@
+Using Groups With NucleosUserBundle
+===================================
+
+NucleosUserBundle allows you to associate groups to your users. Groups are a
+way to group a collection of roles. The roles of a group will be granted
+to all users belonging to it.
+
+.. note::
+
+    Symfony supports role inheritance so inheriting roles from groups is
+    not always needed. If the role inheritance is enough for your use case,
+    it is better to use it instead of groups as it is more efficient (loading
+    the groups triggers the database).
+
+The only mandatory configuration is the fully qualified class
+name (FQCN) of your ``Group`` class which must implement ``Nucleos\UserBundle\Model\GroupInterface``.
+
+Below is an example configuration for enabling groups support.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/nucleos_user.yaml
+        nucleos_user:
+            db_driver: orm
+            firewall_name: main
+            user_class: App\Entity\User
+            group:
+                group_class: App\Entity\Group
+
+The Group class
+---------------
+
+The simplest way to create a Group class is to extend the mapped superclass
+provided by the bundle.
+
+a) ORM Group class implementation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. configuration-block::
+
+    .. code-block:: php-annotations
+
+        // src/Entity/Group.php
+        namespace App\Entity;
+
+        use Doctrine\ORM\Mapping as ORM;
+        use Nucleos\UserBundle\Model\Group as BaseGroup;
+
+        /**
+         * @ORM\Entity
+         * @ORM\Table(name="nucleos_user__group")
+         */
+        class Group extends BaseGroup
+        {
+            /**
+             * @ORM\Id
+             * @ORM\Column(type="integer")
+             * @ORM\GeneratedValue(strategy="AUTO")
+             */
+             protected $id;
+        }
+
+.. note::
+
+    ``Group`` is a reserved keyword in SQL so it cannot be used as the table name.
+
+b) MongoDB Group class implementation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: php
+
+    // src/Document/Group.php
+    namespace App\Document;
+
+    use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+    use Nucleos\UserBundle\Model\Group as BaseGroup;
+
+    /**
+     * @MongoDB\Document
+     */
+    class Group extends BaseGroup
+    {
+        /**
+         * @MongoDB\Id(strategy="auto")
+         */
+        protected $id;
+    }
+
+Defining the User-Group relation
+--------------------------------
+
+The next step is to map the relation in your ``User`` class.
+
+a) ORM User-Group mapping
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. configuration-block::
+
+    .. code-block:: php-annotations
+
+        // src/Entity/User.php
+        namespace App\Entity;
+
+        use Nucleos\UserBundle\Model\User as BaseUser;
+
+        /**
+         * @ORM\Entity
+         * @ORM\Table(name="nucleos_user__user")
+         */
+        class User extends BaseUser
+        {
+            /**
+             * @ORM\Id
+             * @ORM\Column(type="integer")
+             * @ORM\GeneratedValue(strategy="AUTO")
+             */
+            protected $id;
+
+            /**
+             * @ORM\ManyToMany(targetEntity="App\Entity\Group")
+             * @ORM\JoinTable(name="nucleos_user_user_group",
+             *      joinColumns={@ORM\JoinColumn(name="user_id", referencedColumnName="id")},
+             *      inverseJoinColumns={@ORM\JoinColumn(name="group_id", referencedColumnName="id")}
+             * )
+             */
+            protected $groups;
+        }
+
+b) MongoDB User-Group mapping
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: php
+
+    // src/Document/User.php
+    namespace App\Document;
+
+    use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+    use Nucleos\UserBundle\Model\User as BaseUser;
+
+    /**
+     * @MongoDB\Document
+     */
+    class User extends BaseUser
+    {
+        /** @MongoDB\Id(strategy="auto") */
+        protected $id;
+
+        /**
+         * @MongoDB\ReferenceMany(targetDocument="App\Document\Group")
+         */
+        protected $groups;
+    }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,354 @@
+Getting Started With NucleosUserBundle
+======================================
+
+The Symfony Security component provides a flexible security framework that
+allows you to load users from configuration, a database, or anywhere else
+you can imagine. The NucleosUserBundle builds on top of this to make it quick
+and easy to store users in a database, as well as functionality for reset password.
+
+So, if you need to persist and fetch the users in your system to and from
+a database, then you're in the right place.
+
+Prerequisites
+-------------
+
+Translations
+~~~~~~~~~~~~
+
+If you wish to use default texts provided in this bundle, you have to make
+sure you have translator enabled in your config.
+
+.. code-block:: yaml
+
+    # config/packages/framework.yaml
+    framework:
+        translator: ~
+
+For more information about translations, check `Symfony documentation`_.
+
+Installation
+------------
+
+Installation is a quick (I promise!) 7 step process:
+
+1. Download NucleosUserBundle using composer
+2. Enable the Bundle
+3. Create your User class
+4. Configure your application's security.yaml
+5. Configure the NucleosUserBundle
+6. Import NucleosUserBundle routing
+7. Update your database schema
+
+Step 1: Download NucleosUserBundle using composer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Require the bundle with composer:
+
+.. code-block:: bash
+
+    $ composer require nucleos/user-bundle
+
+If you encounter installation errors pointing at a lack of configuration parameters, such as ``The child node "db_driver" at path "nucleos_user" must be configured``, you should complete the configuration in Step 5 first and then re-run this step.
+
+Step 2: Enable the bundle
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enable the bundle in the kernel::
+
+    // config/bundles.php
+    return [
+        // ...
+        Nucleos\UserBundle\NucleosUserBundle::class => ['all' => true],
+        // ...
+    ]
+
+Step 3: Create your User class
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The goal of this bundle is to persist some ``User`` class to a database (MySql,
+MongoDB, etc). Your first job, then, is to create the ``User`` class
+for your application. This class can look and act however you want: add any
+properties or methods you find useful. This is *your* ``User`` class.
+
+The bundle provides base classes which are already mapped for most fields
+to make it easier to create your entity. Here is how you use it:
+
+1. Extend the base ``User`` class (from the ``Model`` folder if you are using
+   any of the doctrine variants)
+2. Map the ``id`` field. It must be protected as it is inherited from the parent class.
+
+.. caution::
+
+    When you extend from the mapped superclass provided by the bundle, don't
+    redefine the mapping for the other fields as it is provided by the bundle.
+
+In the following sections, you'll see examples of how your ``User`` class should
+look, depending on how you're storing your users (Doctrine ORM or MongoDB ODM).
+
+.. note::
+
+    The doc uses a bundle named ``App`` according to the Symfony best
+    practices. However, you can of course place your user class in the bundle
+    you want.
+
+.. caution::
+
+    If you override the __construct() method in your User class, be sure
+    to call parent::__construct(), as the base User class depends on
+    this to initialize some fields.
+
+a) Doctrine ORM User class
+..........................
+
+If you're persisting your users via the Doctrine ORM, then your ``User`` class
+should live in the ``Entity`` namespace of your bundle and look like this to
+start:
+
+.. configuration-block::
+
+    .. code-block:: php-annotations
+
+        // src/Entity/User.php
+        namespace App\Entity;
+
+        use Doctrine\ORM\Mapping as ORM;
+        use Nucleos\UserBundle\Model\User as BaseUser;
+
+        /**
+         * @ORM\Entity
+         * @ORM\Table(name="nucleos_user__user")
+         */
+        class User extends BaseUser
+        {
+            /**
+             * @ORM\Id
+             * @ORM\Column(type="integer")
+             * @ORM\GeneratedValue(strategy="AUTO")
+             */
+            protected $id;
+
+            public function __construct()
+            {
+                parent::__construct();
+                // your own logic
+            }
+        }
+
+.. caution::
+
+    ``user`` is a reserved keyword in the SQL standard. If you need to use reserved words, surround them with backticks, *e.g.* ``@ORM\Table(name="`user`")``
+
+b) MongoDB User class
+.....................
+
+If you're persisting your users via the Doctrine MongoDB ODM, then your ``User``
+class should live in the ``Document`` namespace of your bundle and look like
+this to start::
+
+    // src/Document/User.php
+    namespace App\Document;
+
+    use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+    use Nucleos\UserBundle\Model\User as BaseUser;
+
+    /**
+     * @MongoDB\Document
+     */
+    class User extends BaseUser
+    {
+        /**
+         * @MongoDB\Id(strategy="auto")
+         */
+        protected $id;
+
+        public function __construct()
+        {
+            parent::__construct();
+            // your own logic
+        }
+    }
+
+
+Step 4: Configure your application's security.yaml
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In order for Symfony's security component to use the NucleosUserBundle, you must
+tell it to do so in the ``security.yaml`` file. The ``security.yaml`` file is where the
+basic security configuration for your application is contained.
+
+Below is a minimal example of the configuration necessary to use the NucleosUserBundle
+in your application:
+
+.. code-block:: yaml
+
+    # config/packages/security.yaml
+    security:
+        encoders:
+            Nucleos\UserBundle\Model\UserInterface: bcrypt
+
+        role_hierarchy:
+            ROLE_ADMIN:       ROLE_USER
+            ROLE_SUPER_ADMIN: ROLE_ADMIN
+
+        providers:
+            nucleos_userbundle:
+                id: nucleos_user.user_provider.username
+
+        firewalls:
+            main:
+                pattern: ^/
+                user_checker: nucleos_user.user_checker
+                form_login:
+                    provider: nucleos_userbundle
+                    csrf_token_generator: security.csrf.token_manager
+
+                logout:       true
+                anonymous:    true
+
+        access_control:
+            - { path: ^/login$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+            - { path: ^/resetting, role: IS_AUTHENTICATED_ANONYMOUSLY }
+            # If you have an admin backend, uncomment the following line
+            # - { path: ^/admin/, role: ROLE_ADMIN }
+
+Under the ``providers`` section, you are making the bundle's packaged user provider
+service available via the alias ``nucleos_userbundle``. The id of the bundle's user
+provider service is ``nucleos_user.user_provider.username``.
+
+Next, take a look at and examine the ``firewalls`` section. Here we have
+declared a firewall named ``main``. By specifying ``form_login``, you have
+told the Symfony Framework that any time a request is made to this firewall
+that leads to the user needing to authenticate himself, the user will be
+redirected to a form where he will be able to enter his credentials. It should
+come as no surprise then that you have specified the user provider service
+we declared earlier as the provider for the firewall to use as part of the
+authentication process.
+
+.. note::
+
+    Although we have used the form login mechanism in this example, the NucleosUserBundle
+    user provider service is compatible with many other authentication methods
+    as well. Please read the Symfony Security component documentation for
+    more information on the other types of authentication methods.
+
+The ``access_control`` section is where you specify the credentials necessary for
+users trying to access specific parts of your application. The bundle requires
+that the login form and all the routes used to create a user and reset the password
+be available to unauthenticated users but use the same firewall as
+the pages you want to secure with the bundle. This is why you have specified that
+any request matching the ``/login`` pattern or starting with
+``/resetting`` have been made available to anonymous users. You have also specified
+that any request beginning with ``/admin`` will require a user to have the
+``ROLE_ADMIN`` role.
+
+For more information on configuring the ``security.yaml`` file please read the Symfony
+`security component documentation`_.
+
+.. note::
+
+    Pay close attention to the name, ``main``, that we have given to the
+    firewall which the NucleosUserBundle is configured in. You will use this
+    in the next step when you configure the NucleosUserBundle.
+
+Step 5: Configure the NucleosUserBundle
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Now that you have properly configured your application's ``security.yaml`` to work
+with the NucleosUserBundle, the next step is to configure the bundle to work with
+the specific needs of your application.
+
+Add the following configuration to your ``config/packages/nucleos_user.yaml`` file according to which type
+of datastore you are using.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/nucleos_user.yaml
+        nucleos_user:
+            db_driver: orm # other valid values is 'mongodb'
+            firewall_name: main
+            user_class: App\Entity\User
+            from_email:   "%mailer_user%"
+
+
+Only four configuration's nodes are required to use the bundle:
+
+* The type of datastore you are using (``orm`` or ``mongodb``).
+* The firewall name which you configured in Step 4.
+* The fully qualified class name (FQCN) of the ``User`` class which you created in Step 3.
+
+.. note::
+
+    NucleosUserBundle uses a compiler pass to register mappings for the base
+    User and Group model classes with the object manager that you configured
+    it to use. (Unless specified explicitly, this is the default manager
+    of your doctrine configuration.)
+
+Step 6: Import NucleosUserBundle routing files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Now that you have activated and configured the bundle, all that is left to do is
+import the NucleosUserBundle routing files.
+
+By importing the routing files you will have ready made pages for things such as
+logging in, creating users, etc.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/routes/nucleos_user.yaml
+        nucleos_user:
+            resource: "@NucleosUserBundle/src/Resources/config/routing/all.xml"
+
+.. note::
+
+    In order to use the built-in email functionality (confirmation of the account,
+    resetting of the password), you must activate and configure the SwiftmailerBundle.
+
+Step 7: Update your database schema
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Now that the bundle is configured, the last thing you need to do is update your
+database schema because you have added a new entity, the ``User`` class which you
+created in Step 4.
+
+For ORM run the following command.
+
+.. code-block:: bash
+
+    $ php bin/console doctrine:schema:update --force
+
+For MongoDB users you can run the following command to create the indexes.
+
+.. code-block:: bash
+
+    $ php bin/console doctrine:mongodb:schema:create --index
+
+Next Steps
+~~~~~~~~~~
+
+Now that you have completed the basic installation and configuration of the
+NucleosUserBundle, you are ready to learn about more advanced features and usages
+of the bundle.
+
+The following documents are available:
+
+.. toctree::
+    :maxdepth: 1
+
+    controller_events
+    user_manager
+    command_line_tools
+    logging_by_username_or_email
+    emails
+    groups
+    doctrine
+    canonicalizer
+    custom_storage_layer
+    routing
+    configuration_reference
+
+.. _security component documentation: https://symfony.com/doc/current/book/security.html
+.. _Symfony documentation: https://symfony.com/doc/current/book/translation.html

--- a/docs/logging_by_username_or_email.rst
+++ b/docs/logging_by_username_or_email.rst
@@ -1,0 +1,15 @@
+Logging in by Username or Email
+===============================
+
+The bundle provides a built-in user provider implementation
+using both the username and email fields. To use it, change the id
+of your user provider to use this implementation instead of the base one
+using only the username:
+
+.. code-block:: yaml
+
+    # config/packages/security.yaml
+    security:
+        providers:
+            nucleos_userbundle:
+                id: nucleos_user.user_provider.username_email

--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -1,0 +1,24 @@
+Advanced routing configuration
+==============================
+
+By default, the routing file ``@NucleosUserBundle/src/Resources/config/routing/all.xml`` imports
+all the routing files and enables all the routes.
+In the case you want to enable or disable the different available routes, use the
+single routing configuration files.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/routes/nucleos_user.yaml
+        nucleos_user_security:
+            resource: "@NucleosUserBundle/src/Resources/config/routing/security.xml"
+
+        nucleos_user_resetting:
+            resource: "@NucleosUserBundle/src/Resources/config/routing/resetting.xml"
+            prefix: /resetting
+
+        nucleos_user_change_password:
+            resource: "@NucleosUserBundle/src/Resources/config/routing/change_password.xml"
+            prefix: /security
+

--- a/docs/user_manager.rst
+++ b/docs/user_manager.rst
@@ -1,0 +1,139 @@
+About NucleosUserBundle User Manager
+====================================
+
+In order to be storage agnostic, all operations on the user instances are
+handled by a user manager implementing ``Nucleos\UserBundle\Model\UserManagerInterface``.
+Using it ensures that your code will continue to work if you change the storage.
+The controllers provided by the bundle use the configured user manager instead
+of interacting directly with the storage layer.
+
+If you configure the ``db_driver`` option to ``orm``, this service is an instance
+of ``Nucleos\UserBundle\Doctrine\UserManager``.
+
+If you configure the ``db_driver`` option to ``mongodb``, this service is an
+instance of ``Nucleos\UserBundle\Doctrine\UserManager``.
+
+
+Accessing the User Manager service
+----------------------------------
+
+The user manager is available in the container as a ``Nucleos\UserBundle\Model\UserManagerInterface``
+service::
+
+    use Nucleos\UserBundle\Model\UserManagerInterface;
+
+    public function someAction(UserManagerInterface $manager)
+    {
+        // ...
+    }
+
+Creating a new User
+-------------------
+
+A new instance of your User class can be created by the user manager::
+
+    $user = $userManager->createUser();
+
+``$user`` is now an instance of your user class.
+
+.. note::
+
+    This method will not work if your user class has some mandatory constructor
+    arguments.
+
+Retrieving the users
+--------------------
+
+The user manager has a few methods to find users based on the unique fields
+(username, email and confirmation token) and a method to retrieve all existing
+users.
+
+- ``findUserByUsername($username)``
+- ``findUserByEmail($email)``
+- ``findUserByUsernameOrEmail($value)``  (check if the value looks like an email to choose)
+- ``findUserByConfirmationToken($token)``
+- ``findUserBy(['id'=>$id])``
+- ``findUsers()``
+
+To save a user object, you can use the ``updateUser`` method of the user manager.
+This method will update the encoded password and the canonical fields and
+then persist the changes.
+
+Updating a User object
+----------------------
+
+.. code-block:: php
+
+    $user = $userManager->createUser();
+    $user->setUsername('John');
+    $user->setEmail('john.doe@example.com');
+
+    $userManager->updateUser($user);
+
+.. note::
+
+    To make it easier, the bundle comes with a Doctrine listener handling
+    the update of the password and the canonical fields for you behind the
+    scenes. If you always save the user through the user manager, you may
+    want to disable it to improve performance.
+
+    .. configuration-block::
+
+        .. code-block:: yaml
+
+            # config/packages/nucleos_user.yaml
+            nucleos_user:
+                # ...
+                use_listener: false
+
+.. note::
+
+    For the Doctrine implementations, the default behavior is to flush the
+    unit of work when calling the ``updateUser`` method. You can disable the
+    flush by passing a second argument set to ``false``.
+    This will then be equivalent to calling ``updateCanonicalFields`` and
+    ``updatePassword``.
+
+An ORM example::
+
+    use Nucleos\UserBundle\Model\UserManagerInterface;
+
+    class MainController
+    {
+        public function updateAction(UserManagerInterface $userManager, $id)
+        {
+            $user = // get a user from the datastore
+
+            $user->setEmail($newEmail);
+
+            $userManager->updateUser($user, false);
+
+            // make more modifications to the database
+
+            $this->getDoctrine()->getManager()->flush();
+        }
+    }
+
+Overriding the User Manager
+---------------------------
+
+You can replace the default implementation of the user manager by defining
+a service implementing ``Nucleos\UserBundle\Model\UserManagerInterface`` and
+setting its id in the configuration.
+The id of the default implementation is ``nucleos_user.user_manager.default``
+
+.. code-block:: yaml
+
+    nucleos_user:
+        # ...
+        service:
+            user_manager: custom_user_manager_id
+
+Your custom implementation can extend ``Nucleos\UserBundle\Model\UserManager``
+to reuse the common logic.
+
+SecurityBundle integration
+--------------------------
+
+The bundle provides several implementation of ``Symfony\Component\Security\Core\UserProviderInterface``
+on top of the ``UserManagerInterface``.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #10 

## Subject

Add some basic documentation. This is basically a copy & past of https://github.com/FriendsOfSymfony/FOSUserBundle/ with some adjustments and cleanup:
- Only provide YAML configuration syntax. You can lookup XML service definitation on symfony.com
- Use annotations for entities instead of YAML / XML
- Use `App` instead of `AppBundle`
