### PR TITLE
Find methods could return null

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -171,7 +171,7 @@ parameters:
 			path: src/Doctrine/GroupManager.php
 
 		-
-			message: "#^Method Nucleos\\\\UserBundle\\\\Doctrine\\\\GroupManager\\:\\:findGroupBy\\(\\) should return GroupTemplate of Nucleos\\\\UserBundle\\\\Model\\\\GroupInterface but returns object\\|null\\.$#"
+			message: "#^Method Nucleos\\\\UserBundle\\\\Doctrine\\\\GroupManager\\:\\:findGroupBy\\(\\) should return GroupTemplate of Nucleos\\\\UserBundle\\\\Model\\\\GroupInterface\\|null but returns object\\|null\\.$#"
 			count: 1
 			path: src/Doctrine/GroupManager.php
 

--- a/src/Doctrine/GroupManager.php
+++ b/src/Doctrine/GroupManager.php
@@ -61,9 +61,9 @@ final class GroupManager extends BaseGroupManager
     }
 
     /**
-     * @return GroupTemplate
+     * @return GroupTemplate|null
      */
-    public function findGroupBy(array $criteria): GroupInterface
+    public function findGroupBy(array $criteria): ?GroupInterface
     {
         return $this->repository->findOneBy($criteria);
     }

--- a/src/Model/GroupManager.php
+++ b/src/Model/GroupManager.php
@@ -30,9 +30,9 @@ abstract class GroupManager implements GroupManagerInterface
     }
 
     /**
-     * @return GroupTemplate
+     * @return GroupTemplate|null
      */
-    public function findGroupByName(string $name): GroupInterface
+    public function findGroupByName(string $name): ?GroupInterface
     {
         return $this->findGroupBy(['name' => $name]);
     }

--- a/src/Model/GroupManagerInterface.php
+++ b/src/Model/GroupManagerInterface.php
@@ -33,16 +33,16 @@ interface GroupManagerInterface
     /**
      * Finds one group by the given criteria.
      *
-     * @return GroupTemplate
+     * @return GroupTemplate|null
      */
-    public function findGroupBy(array $criteria): GroupInterface;
+    public function findGroupBy(array $criteria): ?GroupInterface;
 
     /**
      * Finds a group by name.
      *
-     * @return GroupTemplate
+     * @return GroupTemplate|null
      */
-    public function findGroupByName(string $name): GroupInterface;
+    public function findGroupByName(string $name): ?GroupInterface;
 
     /**
      * Returns a collection with all group instances.

--- a/src/Noop/GroupManager.php
+++ b/src/Noop/GroupManager.php
@@ -29,7 +29,7 @@ final class GroupManager extends BaseGroupManager
         throw new NoDriverException();
     }
 
-    public function findGroupBy(array $criteria): GroupInterface
+    public function findGroupBy(array $criteria): ?GroupInterface
     {
         throw new NoDriverException();
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Subject

Call a `findGroupBy*` could find no group and could return null. Technically an API BC break, but this should have never worked.