### PR TITLE
Two Factor Auth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,10 @@
     "description": "Lightweight user management for symfony",
     "keywords": [
         "user management",
+        "securty",
+        "2fa",
+        "two factor",
+        "2-step",
         "symfony"
     ],
     "homepage": "https://nucleos.rocks",

--- a/composer.json
+++ b/composer.json
@@ -109,5 +109,23 @@
         ],
         "phpstan": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/phpunit --colors=always"
-    }
+    },
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/core23"
+        },
+        {
+            "type": "opencollective",
+            "url": "https://opencollective.com/core23"
+        },
+        {
+            "type": "ko-fi",
+            "url": "https://ko-fi.com/core23"
+        },
+        {
+            "type": "other",
+            "url": "https://donate.core23.de"
+        }
+    ]
 }

--- a/docs/configuration_reference.rst
+++ b/docs/configuration_reference.rst
@@ -27,3 +27,11 @@ All available configuration options are listed below with their default values.
         group:
             group_class:    ~ # Required when using groups
             group_manager:  nucleos_user.group_manager.default
+        two_factor:
+            token_length:   4
+            token_ttl:      1800
+            retry_delay:    300
+            retry_limit:    5
+            cookie_name:    device_token
+            token_class:    ~ # Required when using groups
+            trusted_device_class:    ~ # Required when using groups

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ The following documents are available:
     logging_by_username_or_email
     emails
     groups
+    two_factor
     doctrine
     canonicalizer
     custom_storage_layer

--- a/docs/two_factor.rst
+++ b/docs/two_factor.rst
@@ -1,0 +1,188 @@
+Two Factor Auth
+===============
+
+If you want to secure the login, you could enable a two factor protection. When enabled
+the user is asked to enter a security token after the credentials have been entered.
+
+The temporary token is send via mail and is valid for a short time. When entered correctly,
+a device token is stored locally via cookie. The next time the user logins (using the same
+browser), the token is recognized and no new 2FA token is needed.
+
+To enable this feature, you have to create two new entities and define it your configuration.
+
+The ``trusted_device_class`` key must implement the ``Nucleos\UserBundle\Model\TrustedDeviceInterface``
+interface.
+
+.. code-block:: yaml
+
+    # config/packages/nucleos_user.yaml
+    nucleos_user:
+        two_factor:
+            trusted_device_class:    App\Entity\DeviceToken
+
+By default a token is valid for 30 minutes and has a length of 4 characters.
+
+.. code-block:: yaml
+
+    # config/packages/nucleos_user.yaml
+    nucleos_user:
+        two_factor:
+            token_length:   4
+            token_ttl:      1800
+
+After entering 5 wrong tokens, a new token can be requested after 5 minutes.
+
+.. code-block:: yaml
+
+    # config/packages/nucleos_user.yaml
+    nucleos_user:
+        two_factor:
+            retry_delay:    300
+            retry_limit:    5
+
+The device token is stored into a cookie.
+
+.. code-block:: yaml
+
+    # config/packages/nucleos_user.yaml
+    nucleos_user:
+        two_factor:
+            cookie_name:    device_token
+
+The Token class
+---------------
+
+The simplest way to create a Token class is to extend the mapped superclass
+provided by the bundle.
+
+a) ORM Token class implementation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: php-annotations
+
+    // src/Entity/Token.php
+    namespace App\Entity;
+
+    use Doctrine\ORM\Mapping as ORM;
+    use Nucleos\UserBundle\Model\Token as BaseToken;
+
+    /**
+     * @ORM\Entity
+     * @ORM\Table(name="nucleos_user__token")
+     */
+    class Token extends BaseToken
+    {
+        /**
+         * @ORM\Id
+         * @ORM\Column(type="integer")
+         * @ORM\GeneratedValue(strategy="AUTO")
+         */
+         protected $id;
+
+        /**
+         * @ORM\ManyToOne(targetEntity="App\Entity\User",
+         *     cascade={"persist"}
+         * )
+         * @ORM\JoinColumn(name="user_id", referencedColumnName="id", nullable=false)
+         */
+        protected $user;
+    }
+
+b) MongoDB Token class implementation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: php
+
+    // src/Document/Token.php
+    namespace App\Document;
+
+    use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+    use Nucleos\UserBundle\Model\Token as BaseToken;
+
+    /**
+     * @MongoDB\Document
+     */
+    class Token extends BaseToken
+    {
+        /**
+         * @MongoDB\Id(strategy="auto")
+         */
+        protected $id;
+
+        /**
+         * @MongoDB\ManyToOne(targetEntity="App\Entity\User",
+         *     cascade={"persist"}
+         * )
+         * @MongoDB\JoinColumn(name="user_id", referencedColumnName="id", nullable=false)
+         */
+        protected $user;
+    }
+
+The TrustedDevice class
+-----------------------
+
+The simplest way to create a TrustedDevice class is to extend the mapped superclass
+provided by the bundle.
+
+a) ORM TrustedDevice class implementation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: php-annotations
+
+    // src/Entity/TrustedDevice.php
+    namespace App\Entity;
+
+    use Doctrine\ORM\Mapping as ORM;
+    use Nucleos\UserBundle\Model\TrustedDevice as BaseTrustedDevice;
+
+    /**
+     * @ORM\Entity
+     * @ORM\Table(name="nucleos_user__trusted_device")
+     */
+    class TrustedDevice extends BaseTrustedDevice
+    {
+        /**
+         * @ORM\Id
+         * @ORM\Column(type="integer")
+         * @ORM\GeneratedValue(strategy="AUTO")
+         */
+         protected $id;
+
+        /**
+         * @ORM\ManyToOne(targetEntity="App\Entity\User",
+         *     cascade={"persist"}
+         * )
+         * @ORM\JoinColumn(name="user_id", referencedColumnName="id", nullable=false)
+         */
+        protected $user;
+    }
+
+b) MongoDB TrustedDevice class implementation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: php
+
+    // src/Document/TrustedDevice.php
+    namespace App\Document;
+
+    use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+    use Nucleos\UserBundle\Model\TrustedDevice as BaseTrustedDevice;
+
+    /**
+     * @MongoDB\Document
+     */
+    class TrustedDevice extends BaseTrustedDevice
+    {
+        /**
+         * @MongoDB\Id(strategy="auto")
+         */
+        protected $id;
+
+        /**
+         * @MongoDB\ManyToOne(targetEntity="App\Entity\User",
+         *     cascade={"persist"}
+         * )
+         * @MongoDB\JoinColumn(name="user_id", referencedColumnName="id", nullable=false)
+         */
+        protected $user;
+    }

--- a/src/Action/CheckEmailAction.php
+++ b/src/Action/CheckEmailAction.php
@@ -36,9 +36,6 @@ final class CheckEmailAction
      */
     private $retryTtl;
 
-    /**
-     * CheckEmailAction constructor.
-     */
     public function __construct(Environment $twig, RouterInterface $router, int $retryTtl)
     {
         $this->twig     = $twig;

--- a/src/Action/RequestResetAction.php
+++ b/src/Action/RequestResetAction.php
@@ -21,9 +21,6 @@ final class RequestResetAction
      */
     private $twig;
 
-    /**
-     * RequestAction constructor.
-     */
     public function __construct(Environment $twig)
     {
         $this->twig = $twig;

--- a/src/Action/ResetAction.php
+++ b/src/Action/ResetAction.php
@@ -53,9 +53,6 @@ final class ResetAction
      */
     private $userManager;
 
-    /**
-     * ResetAction constructor.
-     */
     public function __construct(
         Environment $twig,
         RouterInterface $router,

--- a/src/Action/SendEmailAction.php
+++ b/src/Action/SendEmailAction.php
@@ -14,7 +14,7 @@ namespace Nucleos\UserBundle\Action;
 use DateTime;
 use Nucleos\UserBundle\Event\GetResponseNullableUserEvent;
 use Nucleos\UserBundle\Event\GetResponseUserEvent;
-use Nucleos\UserBundle\Mailer\MailerInterface;
+use Nucleos\UserBundle\Mailer\ResettingMailer;
 use Nucleos\UserBundle\Model\UserInterface;
 use Nucleos\UserBundle\Model\UserManagerInterface;
 use Nucleos\UserBundle\NucleosUserEvents;
@@ -48,7 +48,7 @@ final class SendEmailAction
     private $tokenGenerator;
 
     /**
-     * @var MailerInterface
+     * @var ResettingMailer
      */
     private $mailer;
 
@@ -62,7 +62,7 @@ final class SendEmailAction
         EventDispatcherInterface $eventDispatcher,
         UserManagerInterface $userManager,
         TokenGeneratorInterface $tokenGenerator,
-        MailerInterface $mailer,
+        ResettingMailer $mailer,
         int $retryTtl
     ) {
         $this->router          = $router;

--- a/src/Action/SendEmailAction.php
+++ b/src/Action/SendEmailAction.php
@@ -57,9 +57,6 @@ final class SendEmailAction
      */
     private $retryTtl;
 
-    /**
-     * SendEmailAction constructor.
-     */
     public function __construct(
         RouterInterface $router,
         EventDispatcherInterface $eventDispatcher,

--- a/src/Action/SendTwoFactorTokenAction.php
+++ b/src/Action/SendTwoFactorTokenAction.php
@@ -1,0 +1,189 @@
+<?php
+
+/*
+ * This file is part of the NucleosUserBundle package.
+ *
+ * (c) Christian Gripp <mail@core23.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nucleos\UserBundle\Action;
+
+use DateTime;
+use Nucleos\UserBundle\Event\GetResponseNullableUserEvent;
+use Nucleos\UserBundle\Event\GetResponseUserEvent;
+use Nucleos\UserBundle\Mailer\TwoFactorMailer;
+use Nucleos\UserBundle\Model\TrustedDeviceInterface;
+use Nucleos\UserBundle\Model\TrustedDeviceManagerInterface;
+use Nucleos\UserBundle\Model\UserInterface;
+use Nucleos\UserBundle\NucleosUserEvents;
+use Nucleos\UserBundle\Util\TokenGeneratorInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class SendTwoFactorTokenAction
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var Security
+     */
+    private $security;
+
+    /**
+     * @var TrustedDeviceManagerInterface
+     */
+    private $trustedDeviceManager;
+
+    /**
+     * @var TokenGeneratorInterface
+     */
+    private $tokenGenerator;
+
+    /**
+     * @var TwoFactorMailer
+     */
+    private $mailer;
+
+    /**
+     * @var int
+     */
+    private $tokenLength;
+
+    /**
+     * @var int
+     */
+    private $tokenTtl;
+
+    /**
+     * @var int
+     */
+    private $retryTtl;
+
+    /**
+     * SendTwoFactorTokenAction constructor.
+     */
+    public function __construct(
+        RouterInterface $router,
+        EventDispatcherInterface $eventDispatcher,
+        Security $security,
+        TrustedDeviceManagerInterface $trustedDeviceManager,
+        TokenGeneratorInterface $tokenGenerator,
+        TwoFactorMailer $mailer,
+        int $tokenLength,
+        int $tokenTtl,
+        int $retryTtl
+    ) {
+        $this->router                  = $router;
+        $this->eventDispatcher         = $eventDispatcher;
+        $this->security                = $security;
+        $this->trustedDeviceManager    = $trustedDeviceManager;
+        $this->tokenGenerator          = $tokenGenerator;
+        $this->mailer                  = $mailer;
+        $this->tokenLength             = $tokenLength;
+        $this->tokenTtl                = $tokenTtl;
+        $this->retryTtl                = $retryTtl;
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        $user = $this->getUser();
+
+        if (null === $user) {
+            return new RedirectResponse($this->router->generate('nucleos_user_security_login'));
+        }
+
+        $response = $this->process($request, $user);
+
+        if (null !== $response) {
+            return $response;
+        }
+
+        return new RedirectResponse($this->router->generate('nucleos_user_two_factor_login'));
+    }
+
+    private function process(Request $request, UserInterface $user): ?Response
+    {
+        $event = new GetResponseNullableUserEvent($user, $request);
+        $this->eventDispatcher->dispatch($event, NucleosUserEvents::TWO_FACTOR_SEND_EMAIL_INITIALIZE);
+
+        if (null !== $event->getResponse()) {
+            return $event->getResponse();
+        }
+
+        if (!$this->hasActiveToken($user)) {
+            $event = new GetResponseUserEvent($user, $request);
+            $this->eventDispatcher->dispatch($event, NucleosUserEvents::TWO_FACTOR_LOGIN_REQUEST);
+
+            if (null !== $event->getResponse()) {
+                return $event->getResponse();
+            }
+
+            $token = $this->createToken($user);
+
+            $event = new GetResponseUserEvent($user, $request);
+            $this->eventDispatcher->dispatch($event, NucleosUserEvents::TWO_FACTOR_SEND_EMAIL_CONFIRM);
+
+            if (null !== $event->getResponse()) {
+                return $event->getResponse();
+            }
+
+            // TODO: Send 2FA token mail
+            $this->mailer->sendTwoFactorMessage($user, $token);
+
+            $this->userManager->updateUser($user);
+
+            $event = new GetResponseUserEvent($user, $request);
+            $this->eventDispatcher->dispatch($event, NucleosUserEvents::TWO_FACTOR_SEND_EMAIL_COMPLETED);
+
+            if (null !== $event->getResponse()) {
+                return $event->getResponse();
+            }
+        }
+
+        return null;
+    }
+
+    private function createToken(UserInterface $user): ?TrustedDeviceInterface
+    {
+        $token    = substr($this->tokenGenerator->generateToken(), 0, $this->tokenLength);
+
+        return $this->trustedDeviceManager->createToken(
+            $user,
+            $token,
+            new DateTime('+'.$this->tokenTtl.' seconds')
+        );
+    }
+
+    private function getUser(): ?UserInterface
+    {
+        $user = $this->security->getUser();
+
+        if ($user instanceof UserInterface) {
+            return $user;
+        }
+
+        return null;
+    }
+
+    private function hasActiveToken(UserInterface $user): bool
+    {
+        // TODO: Check for active token
+
+        return false;
+    }
+}

--- a/src/Action/TwoFactorLoginAction.php
+++ b/src/Action/TwoFactorLoginAction.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the NucleosUserBundle package.
+ *
+ * (c) Christian Gripp <mail@core23.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nucleos\UserBundle\Action;
+
+use Nucleos\UserBundle\Event\FilterUserResponseEvent;
+use Nucleos\UserBundle\Event\FormEvent;
+use Nucleos\UserBundle\Event\GetResponseUserEvent;
+use Nucleos\UserBundle\Form\Model\TwoFactorToken;
+use Nucleos\UserBundle\Form\Type\TwoFactorFormType;
+use Nucleos\UserBundle\Model\TrustedDeviceManagerInterface;
+use Nucleos\UserBundle\Model\UserInterface;
+use Nucleos\UserBundle\NucleosUserEvents;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Twig\Environment;
+
+final class TwoFactorLoginAction
+{
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var Security
+     */
+    private $security;
+
+    /**
+     * @var FormFactoryInterface
+     */
+    private $formFactory;
+
+    /**
+     * @var TrustedDeviceManagerInterface
+     */
+    private $trustedDeviceManager;
+
+    public function __construct(
+        Environment $twig,
+        RouterInterface $router,
+        EventDispatcherInterface $eventDispatcher,
+        Security $security,
+        FormFactoryInterface $formFactory,
+        TrustedDeviceManagerInterface $trustedDeviceManager
+    ) {
+        $this->twig                     = $twig;
+        $this->router                   = $router;
+        $this->eventDispatcher          = $eventDispatcher;
+        $this->security                 = $security;
+        $this->formFactory              = $formFactory;
+        $this->trustedDeviceManager     = $trustedDeviceManager;
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        $user = $this->getUser();
+
+        if (null === $user) {
+            return new RedirectResponse($this->router->generate('nucleos_user_security_login'));
+        }
+
+        $event = new GetResponseUserEvent($user, $request);
+        $this->eventDispatcher->dispatch($event, NucleosUserEvents::TWO_FACTOR_LOGIN_INITIALIZE);
+
+        if (null !== $event->getResponse()) {
+            return $event->getResponse();
+        }
+
+        $form = $this->formFactory->create(TwoFactorFormType::class, new TwoFactorToken($user), [
+            'validation_groups' => ['ResetPassword', 'Default'],
+        ]);
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $event = new FormEvent($form, $request);
+            $this->eventDispatcher->dispatch($event, NucleosUserEvents::TWO_FACTOR_LOGIN_SUCCESS);
+
+            // TODO: Save Token
+
+            if (null === $response = $event->getResponse()) {
+                $url      = $this->router->generate('nucleos_user_security_loggedin');
+                $response = new RedirectResponse($url);
+            }
+
+            $this->eventDispatcher->dispatch(
+                new FilterUserResponseEvent($user, $request, $response),
+                NucleosUserEvents::TWO_FACTOR_LOGIN_COMPLETED
+            );
+
+            return $response;
+        }
+
+        return new Response($this->twig->render('@NucleosUser/TwoFactor/login.html.twig', [
+            'form'  => $form->createView(),
+        ]));
+    }
+
+    private function getUser(): ?UserInterface
+    {
+        $user = $this->security->getUser();
+
+        if ($user instanceof UserInterface) {
+            return $user;
+        }
+
+        return null;
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -64,6 +64,7 @@ final class Configuration implements ConfigurationInterface
         $this->addResettingSection($rootNode);
         $this->addGroupSection($rootNode);
         $this->addServiceSection($rootNode);
+        $this->addTwoFactorSection($rootNode);
 
         return $treeBuilder;
     }
@@ -113,6 +114,38 @@ final class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('group_class')->isRequired()->cannotBeEmpty()->end()
                         ->scalarNode('group_manager')->defaultValue('nucleos_user.group_manager.default')->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addTwoFactorSection(ArrayNodeDefinition $node): void
+    {
+        $node
+            ->children()
+                ->arrayNode('two_factor')
+                    ->canBeUnset()
+                    ->children()
+                        ->integerNode('token_length')->min(4)->max(16)->defaultValue(5)->end()
+                        ->integerNode('token_ttl')
+                            ->defaultValue(1800)
+                            ->info('Lifetime of a generated token in seconds')
+                        ->end()
+                        ->integerNode('retry_delay')
+                            ->defaultValue(300)
+                            ->info('Delay between generating new 2fa token')
+                        ->end()
+                        ->integerNode('retry_limit')
+                            ->defaultValue(5)
+                            ->info('Number of mistyping token before invalidating token')
+                        ->end()
+                        ->scalarNode('cookie_name')
+                            ->defaultValue('device_token')
+                            ->info('Name of the cookie that stores the device token locally')
+                        ->end()
+                        ->scalarNode('token_class')->isRequired()->cannotBeEmpty()->end()
+                        ->scalarNode('trusted_device_class')->isRequired()->cannotBeEmpty()->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -110,7 +110,6 @@ final class Configuration implements ConfigurationInterface
         $node
             ->children()
                 ->arrayNode('group')
-                    ->canBeUnset()
                     ->children()
                         ->scalarNode('group_class')->isRequired()->cannotBeEmpty()->end()
                         ->scalarNode('group_manager')->defaultValue('nucleos_user.group_manager.default')->end()

--- a/src/Doctrine/TrustedDeviceManager.php
+++ b/src/Doctrine/TrustedDeviceManager.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the NucleosUserBundle package.
+ *
+ * (c) Christian Gripp <mail@core23.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nucleos\UserBundle\Doctrine;
+
+use DateTime;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
+use Nucleos\UserBundle\Model\TrustedDeviceInterface;
+use Nucleos\UserBundle\Model\TrustedDeviceManager as BaseTrustedDeviceManager;
+use Nucleos\UserBundle\Model\UserInterface;
+
+final class TrustedDeviceManager extends BaseTrustedDeviceManager
+{
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @var ObjectRepository
+     */
+    private $repository;
+
+    public function __construct(ObjectManager $om, string $class)
+    {
+        $this->objectManager = $om;
+        $this->repository    = $om->getRepository($class);
+
+        $metadata    = $om->getClassMetadata($class);
+        $this->class = $metadata->getName();
+    }
+
+    public function findToken(UserInterface $user, string $token): ?TrustedDeviceInterface
+    {
+        $trustedDevice = $this->repository->findOneBy([
+            'user'  => $user,
+            'token' => $token,
+        ]);
+
+        if ($trustedDevice instanceof TrustedDeviceInterface) {
+            return $trustedDevice;
+        }
+
+        return null;
+    }
+
+    public function removeExpired(): void
+    {
+        $this->repository->createQueryBuilder('t')
+            ->delete()
+            ->where('t.confirmationValidUntil < :now')->setParameter('now', new DateTime());
+    }
+
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+}

--- a/src/EventListener/TwoFactorListener.php
+++ b/src/EventListener/TwoFactorListener.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the NucleosUserBundle package.
+ *
+ * (c) Christian Gripp <mail@core23.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nucleos\UserBundle\EventListener;
+
+use Nucleos\UserBundle\Event\GetResponseUserEvent;
+use Nucleos\UserBundle\Model\TrustedDeviceManagerInterface;
+use Nucleos\UserBundle\Model\UserInterface;
+use Nucleos\UserBundle\NucleosUserEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Routing\Router;
+use Symfony\Component\Security\Core\AuthenticationEvents;
+use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
+
+final class TwoFactorListener implements EventSubscriberInterface
+{
+    public const TWO_FACTOR_EXISTS = '2FA_exists';
+
+    /**
+     * @var TrustedDeviceManagerInterface
+     */
+    private $trustedDeviceManager;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @var Session
+     */
+    private $session;
+
+    /**
+     * @var Router
+     */
+    private $router;
+
+    /**
+     * @var string
+     */
+    private $cookieName;
+
+    public function __construct(
+        TrustedDeviceManagerInterface $trustedDeviceManager,
+        Request $request,
+        Session $session,
+        Router $router,
+        string $cookieName
+    ) {
+        $this->trustedDeviceManager = $trustedDeviceManager;
+        $this->request              = $request;
+        $this->session              = $session;
+        $this->cookieName           = $cookieName;
+        $this->router               = $router;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            AuthenticationEvents::AUTHENTICATION_SUCCESS => 'authSuccess',
+            NucleosUserEvents::SECURITY_LOGIN_COMPLETED  => 'loginCompleted',
+        ];
+    }
+
+    /**
+     * Method is called every time a user is authenticated.
+     */
+    public function authSuccess(AuthenticationSuccessEvent $event): void
+    {
+        $user = $event->getAuthenticationToken()->getUser();
+
+        if ($user instanceof UserInterface && $this->isValidDeviceToken($user)) {
+            $this->session->set(self::TWO_FACTOR_EXISTS, true);
+
+            // TODO: Update Device Token "lastSeen"
+        }
+    }
+
+    /**
+     * Method is called after using the login form.
+     */
+    public function loginCompleted(GetResponseUserEvent $event): void
+    {
+        if ($this->session->has(self::TWO_FACTOR_EXISTS)) {
+            return;
+        }
+
+        $event->setResponse(new RedirectResponse($this->router->generate('nucleos_user_two_factor_send')));
+    }
+
+    private function isValidDeviceToken(UserInterface $user): bool
+    {
+        if ($this->request->cookies->has($this->cookieName)) {
+            return false;
+        }
+
+        $token = $this->request->cookies->get($this->cookieName);
+
+        if (null === $token) {
+            return false;
+        }
+
+        return null !== $this->trustedDeviceManager->findToken($user, $token);
+    }
+}

--- a/src/Form/Model/TwoFactorToken.php
+++ b/src/Form/Model/TwoFactorToken.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the NucleosUserBundle package.
+ *
+ * (c) Christian Gripp <mail@core23.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nucleos\UserBundle\Form\Model;
+
+use Nucleos\UserBundle\Model\UserInterface;
+
+final class TwoFactorToken
+{
+    /**
+     * @var string|null
+     */
+    private $code;
+
+    /**
+     * @var UserInterface
+     */
+    private $user;
+
+    public function __construct(UserInterface $user)
+    {
+        $this->user = $user;
+    }
+
+    public function getCode(): ?string
+    {
+        return $this->code;
+    }
+
+    public function setCode(?string $code): void
+    {
+        $this->code = $code;
+    }
+
+    public function getUser(): UserInterface
+    {
+        return $this->user;
+    }
+}

--- a/src/Form/Type/TwoFactorFormType.php
+++ b/src/Form/Type/TwoFactorFormType.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the NucleosUserBundle package.
+ *
+ * (c) Christian Gripp <mail@core23.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nucleos\UserBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class TwoFactorFormType extends AbstractType
+{
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @param string $class The User class name
+     */
+    public function __construct(string $class)
+    {
+        $this->class = $class;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('code', TextType::class, [
+            'label'              => 'form.current_code',
+            'translation_domain' => 'NucleosUserBundle',
+        ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class'    => $this->class,
+        ]);
+    }
+}

--- a/src/Mailer/Mail/TwoFactorMail.php
+++ b/src/Mailer/Mail/TwoFactorMail.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the NucleosUserBundle package.
+ *
+ * (c) Christian Gripp <mail@core23.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nucleos\UserBundle\Mailer\Mail;
+
+use Nucleos\UserBundle\Model\TrustedDeviceInterface;
+use Nucleos\UserBundle\Model\UserInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mime\Header\Headers;
+use Symfony\Component\Mime\Part\AbstractPart;
+
+final class TwoFactorMail extends TemplatedEmail
+{
+    /**
+     * @var string
+     */
+    private $confirmationUrl;
+
+    /**
+     * @var TrustedDeviceInterface
+     */
+    private $token;
+
+    /**
+     * @var UserInterface
+     */
+    private $user;
+
+    public function __construct(Headers $headers = null, AbstractPart $body = null)
+    {
+        parent::__construct($headers, $body);
+
+        $this->htmlTemplate('@NucleosUser/TwoFactor/email.txt.twig');
+    }
+
+    public function setConfirmationUrl(string $confirmationUrl): self
+    {
+        $this->confirmationUrl = $confirmationUrl;
+
+        return $this;
+    }
+
+    public function setUser(UserInterface $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function setToken(TrustedDeviceInterface $token): self
+    {
+        $this->token = $token;
+
+        return $this;
+    }
+
+    public function getConfirmationUrl(): string
+    {
+        return $this->confirmationUrl;
+    }
+
+    public function getUser(): UserInterface
+    {
+        return $this->user;
+    }
+
+    public function getToken(): TrustedDeviceInterface
+    {
+        return $this->token;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function getContext(): array
+    {
+        return array_merge([
+            'user'             => $this->getUser(),
+            'confirmationUrl'  => $this->getConfirmationUrl(),
+            'token'            => $this->getToken(),
+        ], parent::getContext());
+    }
+}

--- a/src/Mailer/ResettingMailer.php
+++ b/src/Mailer/ResettingMailer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the NucleosUserBundle package.
  *
@@ -13,9 +11,9 @@ declare(strict_types=1);
 
 namespace Nucleos\UserBundle\Mailer;
 
-/**
- * @deprecated since 1.4.0, use ResettingMailer instead
- */
-interface MailerInterface extends ResettingMailer
+use Nucleos\UserBundle\Model\UserInterface;
+
+interface ResettingMailer
 {
+    public function sendResettingEmailMessage(UserInterface $user): void;
 }

--- a/src/Mailer/TwoFactorMailer.php
+++ b/src/Mailer/TwoFactorMailer.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Nucleos\UserBundle\Util;
+namespace Nucleos\UserBundle\Mailer;
 
-final class TokenGenerator implements TokenGeneratorInterface
+use Nucleos\UserBundle\Model\TrustedDeviceInterface;
+use Nucleos\UserBundle\Model\UserInterface;
+
+interface TwoFactorMailer
 {
-    public function generateToken(int $length = 32): string
-    {
-        return rtrim(strtr(base64_encode(random_bytes($length)), '+/', '-_'), '=');
-    }
+    public function sendTwoFactorMessage(UserInterface $user, TrustedDeviceInterface $token): void;
 }

--- a/src/Model/TrustedDevice.php
+++ b/src/Model/TrustedDevice.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the NucleosUserBundle package.
+ *
+ * (c) Christian Gripp <mail@core23.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nucleos\UserBundle\Model;
+
+use DateTime;
+
+abstract class TrustedDevice implements TrustedDeviceInterface
+{
+    /**
+     * @var UserInterface
+     */
+    protected $user;
+
+    /**
+     * @var string
+     */
+    protected $token;
+
+    /**
+     * @var string|null
+     */
+    protected $confirmationCode;
+
+    /**
+     * @var int
+     */
+    protected $confirmationRetry = 0;
+
+    /**
+     * @var DateTime|null
+     */
+    protected $confirmationValidUntil;
+
+    /**
+     * @var string|null
+     */
+    protected $lastIp;
+
+    /**
+     * @var DateTime|null
+     */
+    protected $lastSeen;
+
+    public function __construct(UserInterface $user, string $token)
+    {
+        $this->user  = $user;
+        $this->token = $token;
+    }
+
+    public function getUser(): UserInterface
+    {
+        return $this->user;
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
+    public function getLastIp(): ?string
+    {
+        return $this->lastIp;
+    }
+
+    public function getLastSeen(): ?DateTime
+    {
+        return $this->lastSeen;
+    }
+
+    public function updateLastSeen(DateTime $date, string $ip): void
+    {
+        $this->lastSeen = $date;
+        $this->lastIp   = $ip;
+    }
+
+    public function getConfirmationCode(): ?string
+    {
+        return $this->confirmationCode;
+    }
+
+    public function getConfirmationRetry(): int
+    {
+        return $this->confirmationRetry;
+    }
+
+    public function getConfirmationValidUntil(): ?DateTime
+    {
+        return $this->confirmationValidUntil;
+    }
+}

--- a/src/Model/TrustedDeviceInterface.php
+++ b/src/Model/TrustedDeviceInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the NucleosUserBundle package.
+ *
+ * (c) Christian Gripp <mail@core23.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nucleos\UserBundle\Model;
+
+use DateTime;
+
+interface TrustedDeviceInterface
+{
+    public function getUser(): UserInterface;
+
+    public function getToken(): string;
+
+    public function getLastIp(): ?string;
+
+    public function getLastSeen(): ?DateTime;
+
+    public function updateLastSeen(DateTime $date, string $ip): void;
+}

--- a/src/Model/TrustedDeviceManager.php
+++ b/src/Model/TrustedDeviceManager.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the NucleosUserBundle package.
+ *
+ * (c) Christian Gripp <mail@core23.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nucleos\UserBundle\Model;
+
+use DateTimeInterface;
+
+abstract class TrustedDeviceManager implements TrustedDeviceManagerInterface
+{
+    public function createToken(UserInterface $user, string $code, DateTimeInterface $expiryDate): ?TrustedDeviceInterface
+    {
+        $class = $this->getClass();
+
+        return new $class($user, $code, $expiryDate);
+    }
+}

--- a/src/Model/TrustedDeviceManagerInterface.php
+++ b/src/Model/TrustedDeviceManagerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the NucleosUserBundle package.
+ *
+ * (c) Christian Gripp <mail@core23.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nucleos\UserBundle\Model;
+
+use DateTimeInterface;
+
+interface TrustedDeviceManagerInterface
+{
+    public function findToken(UserInterface $user, string $token): ?TrustedDeviceInterface;
+
+    public function createToken(UserInterface $user, string $code, DateTimeInterface $expiryDate): ?TrustedDeviceInterface;
+
+    public function removeExpired(): void;
+
+    /**
+     * @phpstan-return string-class<TrustedDeviceInterface>
+     */
+    public function getClass(): string;
+}

--- a/src/Noop/TrustedDeviceManager.php
+++ b/src/Noop/TrustedDeviceManager.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the NucleosUserBundle package.
+ *
+ * (c) Christian Gripp <mail@core23.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nucleos\UserBundle\Noop;
+
+use Nucleos\UserBundle\Model\TrustedDeviceInterface;
+use Nucleos\UserBundle\Model\TrustedDeviceManager as BaseTrustedDeviceManager;
+use Nucleos\UserBundle\Model\UserInterface;
+use Nucleos\UserBundle\Noop\Exception\NoDriverException;
+
+final class TrustedDeviceManager extends BaseTrustedDeviceManager
+{
+    public function findToken(UserInterface $user, string $token): TrustedDeviceInterface
+    {
+        throw new NoDriverException();
+    }
+
+    public function removeExpired(): void
+    {
+        throw new NoDriverException();
+    }
+
+    public function getClass(): string
+    {
+        throw new NoDriverException();
+    }
+}

--- a/src/NucleosUserEvents.php
+++ b/src/NucleosUserEvents.php
@@ -155,6 +155,43 @@ final class NucleosUserEvents
     public const RESETTING_RESET_COMPLETED = 'nucleos_user.resetting.reset.completed';
 
     /**
+     * The TWO_FACTOR_LOGIN_REQUEST event occurs when a user tries to login without a device token.
+     *
+     * This event allows you to check intercept the flow before redirecting to the two factor form.
+     * The event listener method receives a Nucleos\UserBundle\Event\GetResponseUserEvent instance.
+     *
+     * @Event("Nucleos\UserBundle\Event\GetResponseUserEvent")
+     */
+    public const TWO_FACTOR_LOGIN_REQUEST = 'nucleos_user.two_factor.login.request';
+
+    /**
+     * The TWO_FACTOR_LOGIN_INITIALIZE event occurs when the two factor form is initialized.
+     *
+     * This event allows you to set the response to bypass the processing.
+     *
+     * @Event("Nucleos\UserBundle\Event\GetResponseUserEvent")
+     */
+    public const TWO_FACTOR_LOGIN_INITIALIZE = 'nucleos_user.two_factor.login.initialize';
+
+    /**
+     * The TWO_FACTOR_LOGIN_SUCCESS event occurs when the two factor  form is submitted successfully.
+     *
+     * This event allows you to set the response instead of using the default one.
+     *
+     * @Event("Nucleos\UserBundle\Event\FormEvent ")
+     */
+    public const TWO_FACTOR_LOGIN_SUCCESS = 'nucleos_user.two_factor.login.success';
+
+    /**
+     * The TWO_FACTOR_LOGIN_COMPLETED event occurs after saving the device token in the two factor process.
+     *
+     * This event allows you to access the response which will be sent.
+     *
+     * @Event("Nucleos\UserBundle\Event\FilterUserResponseEvent")
+     */
+    public const TWO_FACTOR_LOGIN_COMPLETED = 'nucleos_user.two_factor.login.completed';
+
+    /**
      * The SECURITY_LOGIN_INITIALIZE event occurs when the send email process is initialized.
      *
      * This event allows you to set the response to bypass the login.
@@ -213,4 +250,35 @@ final class NucleosUserEvents
      * @Event("Nucleos\UserBundle\Event\GetResponseUserEvent")
      */
     public const RESETTING_SEND_EMAIL_COMPLETED = 'nucleos_user.resetting.send_email.completed';
+
+    /**
+     * The TWO_FACTOR_SEND_EMAIL_INITIALIZE event occurs when the send email process is initialized.
+     *
+     * This event allows you to set the response to bypass the email confirmation processing.
+     * The event listener method receives a Nucleos\UserBundle\Event\GetResponseNullableUserEvent instance.
+     *
+     * @Event("Nucleos\UserBundle\Event\GetResponseNullableUserEvent")
+     */
+    public const TWO_FACTOR_SEND_EMAIL_INITIALIZE = 'nucleos_user.resetting.send_email.initialize';
+
+    /**
+     * The TWO_FACTOR_SEND_EMAIL_CONFIRM event occurs when all prerequisites to send email are
+     * confirmed and before the mail is sent.
+     *
+     * This event allows you to set the response to bypass the email sending.
+     * The event listener method receives a Nucleos\UserBundle\Event\GetResponseUserEvent instance.
+     *
+     * @Event("Nucleos\UserBundle\Event\GetResponseUserEvent")
+     */
+    public const TWO_FACTOR_SEND_EMAIL_CONFIRM = 'nucleos_user.resetting.send_email.confirm';
+
+    /**
+     * The TWO_FACTOR_SEND_EMAIL_COMPLETED event occurs after the email is sent.
+     *
+     * This event allows you to set the response to bypass the the redirection after the email is sent.
+     * The event listener method receives a Nucleos\UserBundle\Event\GetResponseUserEvent instance.
+     *
+     * @Event("Nucleos\UserBundle\Event\GetResponseUserEvent")
+     */
+    public const TWO_FACTOR_SEND_EMAIL_COMPLETED = 'nucleos_user.resetting.send_email.completed';
 }

--- a/src/Resources/config/doctrine-mapping/Token.mongodb.xml
+++ b/src/Resources/config/doctrine-mapping/Token.mongodb.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+  <mapped-superclass name="Nucleos\UserBundle\Model\Token" collection="nucleos_user__token">
+    <field name="code" type="string"/>
+    <field name="validUntil" type="date"/>
+    <field name="retry" type="int"/>
+  </mapped-superclass>
+</doctrine-mongo-mapping>

--- a/src/Resources/config/doctrine-mapping/Token.orm.xml
+++ b/src/Resources/config/doctrine-mapping/Token.orm.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping                   http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <mapped-superclass name="Nucleos\UserBundle\Model\Token">
+    <field name="code" column="code" type="string" length="16"/>
+    <field name="validUntil" column="valid_until" type="datetime"/>
+    <field name="retry" column="retry" type="smallint"/>
+  </mapped-superclass>
+</doctrine-mapping>

--- a/src/Resources/config/doctrine-mapping/TrustedDevice.mongodb.xml
+++ b/src/Resources/config/doctrine-mapping/TrustedDevice.mongodb.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+  <mapped-superclass name="Nucleos\UserBundle\Model\TrustedDevice" collection="nucleos_user__trusted_device">
+    <field name="token" type="string"/>
+    <field name="lastIp" type="string"/>
+    <field name="lastSeen" type="date"/>
+  </mapped-superclass>
+</doctrine-mongo-mapping>

--- a/src/Resources/config/doctrine-mapping/TrustedDevice.orm.xml
+++ b/src/Resources/config/doctrine-mapping/TrustedDevice.orm.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping                   http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <mapped-superclass name="Nucleos\UserBundle\Model\TrustedDevice">
+    <field name="token" column="token" type="string" length="180"/>
+    <field name="lastIp" column="last_ip" type="string" length="39"/>
+    <field name="lastSeen" column="last_seen" type="datetime" nullable="true"/>
+  </mapped-superclass>
+</doctrine-mapping>

--- a/src/Resources/config/doctrine_two_factor.xml
+++ b/src/Resources/config/doctrine_two_factor.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Nucleos\UserBundle\Model\TrustedDeviceManagerInterface" alias="Nucleos\UserBundle\Doctrine\TrustedDeviceManager"/>
+    <service id="Nucleos\UserBundle\Doctrine\TrustedDeviceManager">
+      <argument type="service" id="nucleos_user.object_manager"/>
+      <argument>%nucleos_user.model.trusted_device.class%</argument>
+    </service>
+  </services>
+</container>

--- a/src/Resources/config/noop_two_factor.xml
+++ b/src/Resources/config/noop_two_factor.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Nucleos\UserBundle\Model\TrustedDeviceManagerInterface" alias="Nucleos\UserBundle\Noop\TrustedDeviceManager"/>
+    <service id="Nucleos\UserBundle\Noop\TrustedDeviceManager"/>
+  </services>
+</container>

--- a/src/Resources/config/routing/two_factor.xml
+++ b/src/Resources/config/routing/two_factor.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+  <route id="nucleos_user_two_factor_login" path="/login/confirm" methods="GET">
+    <default key="_controller">Nucleos\UserBundle\Action\ConfirmLoginAction</default>
+  </route>
+  <route id="nucleos_user_two_factor_send" path="/login/sendToken" methods="GET">
+    <default key="_controller">Nucleos\UserBundle\Action\SendTwoFactorTokenAction</default>
+  </route>
+</routes>

--- a/src/Resources/config/two_factor.xml
+++ b/src/Resources/config/two_factor.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Nucleos\UserBundle\Action\TwoFactorLoginAction" public="true">
+      <argument type="service" id="twig"/>
+      <argument type="service" id="router"/>
+      <argument type="service" id="event_dispatcher"/>
+      <argument type="service" id="security.helper"/>
+      <argument type="service" id="form.factory"/>
+      <argument type="service" id="Nucleos\UserBundle\Model\TrustedDeviceManagerInterface"/>
+    </service>
+    <service id="Nucleos\UserBundle\Action\SendTwoFactorTokenAction" public="true">
+      <argument type="service" id="router"/>
+      <argument type="service" id="event_dispatcher"/>
+      <argument type="service" id="security.helper"/>
+      <argument type="service" id="nucleos_user.util.token_generator"/>
+      <argument type="service" id="Nucleos\UserBundle\Mailer\TwoFactorMailer"/>
+      <argument>%nucleos_user.two_factor.retry_ttl%</argument>
+    </service>
+    <service id="Nucleos\UserBundle\EventListener\TwoFactorListener">
+      <tag name="kernel.event_subscriber"/>
+      <argument type="service" id="Nucleos\UserBundle\Model\TrustedDeviceManagerInterface"/>
+      <argument type="service" id="request"/>
+      <argument type="service" id="session"/>
+      <argument type="service" id="router"/>
+    </service>
+  </services>
+</container>

--- a/src/Resources/translations/NucleosUserBundle.de.yml
+++ b/src/Resources/translations/NucleosUserBundle.de.yml
@@ -42,7 +42,23 @@ form:
     username: Benutzername
     email: E-Mail-Adresse
     current_password: 'Derzeitiges Passwort'
+    current_code: 'Aktueller Code'
     password: Passwort
     password_confirmation: 'Passwort bestätigen'
     new_password: 'Neues Passwort'
     new_password_confirmation: 'Neues Passwort bestätigen'
+
+two_factor:
+  email:
+      subject: 'Anmeldung bestätigen'
+      message: |
+          Hallo %username%!
+
+          wir wollen dein Konto schützen. Bitte melde dich unter %confirmationUrl% and und bestätige dieses mit den folgenden Code:
+
+          %code%
+
+          Mit besten Grüßen,
+          das Team.
+   login:
+     submit: 'Einloggen'

--- a/src/Resources/translations/NucleosUserBundle.en.yml
+++ b/src/Resources/translations/NucleosUserBundle.en.yml
@@ -42,7 +42,23 @@ form:
     username: Username
     email: Email
     current_password: 'Current password'
+    current_code: 'Current code'
     password: Password
     password_confirmation: 'Repeat password'
     new_password: 'New password'
     new_password_confirmation: 'Repeat new password'
+
+two_factor:
+  email:
+      subject: 'Confirm login'
+      message: |
+          Hello %username%!
+
+          we try to protect you account. Please visit %confirmationUrl% and confirm your login using the following code:
+
+          %code%
+
+          Regards,
+          the Team.
+  login:
+    submit: 'Login'

--- a/src/Resources/views/TwoFactor/email.txt.twig
+++ b/src/Resources/views/TwoFactor/email.txt.twig
@@ -1,0 +1,7 @@
+{% trans_default_domain 'NucleosUserBundle' %}
+
+{{ 'two_factor.email.message'|trans({
+    '%username%': user.username,
+    '%code%': token.code,
+    '%confirmationUrl%': confirmationUrl
+}) }}

--- a/src/Resources/views/TwoFactor/login.html.twig
+++ b/src/Resources/views/TwoFactor/login.html.twig
@@ -1,0 +1,5 @@
+{% extends "@NucleosUser/layout.html.twig" %}
+
+{% block nucleos_user_content %}
+    {% include "@NucleosUser/TwoFactor/login_content.html.twig" %}
+{% endblock nucleos_user_content %}

--- a/src/Resources/views/TwoFactor/login_content.html.twig
+++ b/src/Resources/views/TwoFactor/login_content.html.twig
@@ -1,0 +1,12 @@
+{% trans_default_domain 'NucleosUserBundle' %}
+
+{% form_theme form 'bootstrap_3_horizontal_layout.html.twig' %}
+
+{{ form_start(form, { 'action': path('nucleos_user_two_factor_login', {'token': token}) }) }}
+    {{ form_widget(form) }}
+    <div class="form-group">
+        <div class="col-sm-offset-2 col-sm-10">
+            <input type="submit" class="btn btn-primary" value="{{ 'two_factor.login.submit'|trans }}"/>
+        </div>
+    </div>
+{{ form_end(form) }}

--- a/tests/App/Entity/TestToken.php
+++ b/tests/App/Entity/TestToken.php
@@ -11,12 +11,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Nucleos\UserBundle\Util;
+namespace Nucleos\UserBundle\Tests\App\Entity;
 
-final class TokenGenerator implements TokenGeneratorInterface
+use Nucleos\UserBundle\Model\Token;
+
+class TestToken extends Token
 {
-    public function generateToken(int $length = 32): string
-    {
-        return rtrim(strtr(base64_encode(random_bytes($length)), '+/', '-_'), '=');
-    }
 }

--- a/tests/App/Entity/TestTrustedDevice.php
+++ b/tests/App/Entity/TestTrustedDevice.php
@@ -11,12 +11,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Nucleos\UserBundle\Util;
+namespace Nucleos\UserBundle\Tests\App\Entity;
 
-final class TokenGenerator implements TokenGeneratorInterface
+use Nucleos\UserBundle\Model\TrustedDevice;
+
+class TestTrustedDevice extends TrustedDevice
 {
-    public function generateToken(int $length = 32): string
-    {
-        return rtrim(strtr(base64_encode(random_bytes($length)), '+/', '-_'), '=');
-    }
 }

--- a/tests/App/config/config.yaml
+++ b/tests/App/config/config.yaml
@@ -22,6 +22,3 @@ nucleos_user:
     from_email:  'no-reply@localhost'
 
     user_class:  'Nucleos\UserBundle\Tests\App\Entity\User'
-
-    group:
-        group_class: 'Nucleos\UserBundle\Tests\App\Entity\Group'

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -13,6 +13,8 @@ namespace Nucleos\UserBundle\Tests\DependencyInjection;
 
 use Nucleos\UserBundle\DependencyInjection\Configuration;
 use Nucleos\UserBundle\Tests\App\Entity\TestGroup;
+use Nucleos\UserBundle\Tests\App\Entity\TestToken;
+use Nucleos\UserBundle\Tests\App\Entity\TestTrustedDevice;
 use Nucleos\UserBundle\Tests\App\Entity\TestUser;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Processor;
@@ -85,6 +87,46 @@ class ConfigurationTest extends TestCase
         static::assertSame($expected, $config);
     }
 
+    public function testOptionsWithTwoFactor(): void
+    {
+        $processor = new Processor();
+
+        $config = $processor->processConfiguration(new Configuration(), [$this->basicConfigWithTwoFactor()]);
+
+        $expected = [
+            'firewall_name'                      => 'test',
+            'from_email'                         => 'no-reply@localhost',
+            'user_class'                         => TestUser::class,
+            'two_factor'                         => [
+                'token_class'          => TestToken::class,
+                'trusted_device_class' => TestTrustedDevice::class,
+                'token_length'         => 5,
+                'token_ttl'            => 1800,
+                'retry_delay'          => 300,
+                'retry_limit'          => 5,
+                'cookie_name'          => 'device_token',
+            ],
+            'db_driver'                   => 'noop',
+            'model_manager_name'          => null,
+            'use_authentication_listener' => true,
+            'use_listener'                => true,
+            'use_flash_notifications'     => true,
+            'resetting'                   => [
+                'retry_ttl' => 7200,
+                'token_ttl' => 86400,
+            ],
+            'service' => [
+                'mailer'                 => 'nucleos_user.mailer.default',
+                'email_canonicalizer'    => 'nucleos_user.util.canonicalizer.default',
+                'token_generator'        => 'nucleos_user.util.token_generator.default',
+                'username_canonicalizer' => 'nucleos_user.util.canonicalizer.default',
+                'user_manager'           => 'nucleos_user.user_manager.default',
+            ],
+        ];
+
+        static::assertSame($expected, $config);
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -108,6 +150,22 @@ class ConfigurationTest extends TestCase
             'user_class'    => TestUser::class,
             'group'         => [
                 'group_class' => TestGroup::class,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function basicConfigWithTwoFactor(): array
+    {
+        return [
+            'firewall_name'        => 'test',
+            'from_email'           => 'no-reply@localhost',
+            'user_class'           => TestUser::class,
+            'two_factor'           => [
+                'token_class'          => TestToken::class,
+                'trusted_device_class' => TestTrustedDevice::class,
             ],
         ];
     }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the NucleosUserBundle package.
+ *
+ * (c) Christian Gripp <mail@core23.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nucleos\UserBundle\Tests\DependencyInjection;
+
+use Nucleos\UserBundle\DependencyInjection\Configuration;
+use Nucleos\UserBundle\Tests\App\Entity\TestGroup;
+use Nucleos\UserBundle\Tests\App\Entity\TestUser;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Processor;
+
+class ConfigurationTest extends TestCase
+{
+    public function testDefaultOptions(): void
+    {
+        $processor = new Processor();
+
+        $config = $processor->processConfiguration(new Configuration(), [$this->basicConfig()]);
+
+        $expected = [
+            'firewall_name'               => 'test',
+            'from_email'                  => 'no-reply@localhost',
+            'user_class'                  => TestUser::class,
+            'db_driver'                   => 'noop',
+            'model_manager_name'          => null,
+            'use_authentication_listener' => true,
+            'use_listener'                => true,
+            'use_flash_notifications'     => true,
+            'resetting'                   => [
+                'retry_ttl' => 7200,
+                'token_ttl' => 86400,
+            ],
+            'service' => [
+                'mailer'                 => 'nucleos_user.mailer.default',
+                'email_canonicalizer'    => 'nucleos_user.util.canonicalizer.default',
+                'token_generator'        => 'nucleos_user.util.token_generator.default',
+                'username_canonicalizer' => 'nucleos_user.util.canonicalizer.default',
+                'user_manager'           => 'nucleos_user.user_manager.default',
+            ],
+        ];
+
+        static::assertSame($expected, $config);
+    }
+
+    public function testOptionsWithGroup(): void
+    {
+        $processor = new Processor();
+
+        $config = $processor->processConfiguration(new Configuration(), [$this->basicConfigWithGroup()]);
+
+        $expected = [
+            'firewall_name'               => 'test',
+            'from_email'                  => 'no-reply@localhost',
+            'user_class'                  => TestUser::class,
+            'group'                       => [
+                'group_class'   => TestGroup::class,
+                'group_manager' => 'nucleos_user.group_manager.default',
+            ],
+            'db_driver'                   => 'noop',
+            'model_manager_name'          => null,
+            'use_authentication_listener' => true,
+            'use_listener'                => true,
+            'use_flash_notifications'     => true,
+            'resetting'                   => [
+                'retry_ttl' => 7200,
+                'token_ttl' => 86400,
+            ],
+            'service' => [
+                'mailer'                 => 'nucleos_user.mailer.default',
+                'email_canonicalizer'    => 'nucleos_user.util.canonicalizer.default',
+                'token_generator'        => 'nucleos_user.util.token_generator.default',
+                'username_canonicalizer' => 'nucleos_user.util.canonicalizer.default',
+                'user_manager'           => 'nucleos_user.user_manager.default',
+            ],
+        ];
+
+        static::assertSame($expected, $config);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function basicConfig(): array
+    {
+        return [
+            'firewall_name' => 'test',
+            'from_email'    => 'no-reply@localhost',
+            'user_class'    => TestUser::class,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function basicConfigWithGroup(): array
+    {
+        return [
+            'firewall_name' => 'test',
+            'from_email'    => 'no-reply@localhost',
+            'user_class'    => TestUser::class,
+            'group'         => [
+                'group_class' => TestGroup::class,
+            ],
+        ];
+    }
+}

--- a/tests/DependencyInjection/NucleosUserExtensionTest.php
+++ b/tests/DependencyInjection/NucleosUserExtensionTest.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace Nucleos\UserBundle\Tests\DependencyInjection;
 
 use Nucleos\UserBundle\DependencyInjection\NucleosUserExtension;
+use Nucleos\UserBundle\Doctrine\TrustedDeviceManager;
 use Nucleos\UserBundle\EventListener\FlashListener;
+use Nucleos\UserBundle\Model\TrustedDeviceManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -124,6 +126,7 @@ final class NucleosUserExtensionTest extends TestCase
         $this->assertParameter('custom', 'nucleos_user.model_manager_name');
         $this->assertAlias('acme_my.user_manager', 'nucleos_user.user_manager');
         $this->assertAlias('nucleos_user.group_manager.default', 'nucleos_user.group_manager');
+        $this->assertAlias(TrustedDeviceManager::class, TrustedDeviceManagerInterface::class);
     }
 
     public function testUserLoadUtilServiceWithDefaults(): void
@@ -243,6 +246,14 @@ service:
     user_manager: acme_my.user_manager
 group:
     group_class: Acme\MyBundle\Entity\Group
+two_factor:
+    token_length:   4
+    token_ttl:      1800
+    retry_delay:    300
+    retry_limit:    5
+    cookie_name:    device_token
+    token_class:    Acme\MyBundle\Entity\Token
+    trusted_device_class:    Acme\MyBundle\Entity\DeviceToken
 EOF;
         $parser = new Parser();
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

Introduce a new feature that supports basic two factor authentication.

When you login with the right credentials, you will see an other dialog that asks for a short confirmation code. This code is send via mail and has a short TTL. After confirming the token, you are successfully logged in. A new device token is stored via cookie and persisted in the database.

When you sign off and later sign on again (using the same browser / system) you will be remembered via a trusted device cookie and you won't see a two factor login form.

# To Do
- [ ] Add login interceptor to show 2FA prompt
- [ ] Send confirmation mail
- [ ] Allow regenerating new token
- [ ] Remove old 2 factor tokens
- [ ] Show current active device tokens
- [ ] Allow deleting some device tokens
- [ ] Limit device tokens
