### PR TITLE
Remove deprecated mongo safe option

### DIFF
--- a/src/Resources/config/doctrine-mapping/Group.mongodb.xml
+++ b/src/Resources/config/doctrine-mapping/Group.mongodb.xml
@@ -6,7 +6,6 @@
     <indexes>
       <index>
         <key name="name" order="asc"/>
-        <option name="safe" value="true"/>
         <option name="unique" value="true"/>
       </index>
     </indexes>

--- a/src/Resources/config/doctrine-mapping/User.mongodb.xml
+++ b/src/Resources/config/doctrine-mapping/User.mongodb.xml
@@ -17,17 +17,14 @@
     <indexes>
       <index>
         <key name="usernameCanonical" order="asc"/>
-        <option name="safe" value="true"/>
         <option name="unique" value="true"/>
       </index>
       <index>
         <key name="emailCanonical" order="asc"/>
-        <option name="safe" value="true"/>
         <option name="unique" value="true"/>
       </index>
       <index>
         <key name="confirmationToken" order="asc"/>
-        <option name="safe" value="true"/>
         <option name="sparse" value="true"/>
         <option name="unique" value="true"/>
       </index>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #35

## Subject

The `safe` options is deprecated and removed in odm 2.0: https://github.com/doctrine/mongodb-odm/blob/5e6dee817947730342aec238782d2233f8abba48/UPGRADE-2.0.md#general-mapping-changes
