### PR TITLE
Add setPlainPassword() before update user

### DIFF
--- a/src/Action/ChangePasswordAction.php
+++ b/src/Action/ChangePasswordAction.php
@@ -104,7 +104,9 @@ final class ChangePasswordAction
         if ($form->isSubmitted() && $form->isValid()) {
             $event = new FormEvent($form, $request);
             $this->eventDispatcher->dispatch($event, NucleosUserEvents::CHANGE_PASSWORD_SUCCESS);
-
+            
+            $user->setPlainPassword($form->getData()->getPlainPassword());
+            
             $this->userManager->updateUser($user);
 
             if (null === $response = $event->getResponse()) {

--- a/src/Action/ChangePasswordAction.php
+++ b/src/Action/ChangePasswordAction.php
@@ -104,9 +104,9 @@ final class ChangePasswordAction
         if ($form->isSubmitted() && $form->isValid()) {
             $event = new FormEvent($form, $request);
             $this->eventDispatcher->dispatch($event, NucleosUserEvents::CHANGE_PASSWORD_SUCCESS);
-            
+
             $user->setPlainPassword($form->getData()->getPlainPassword());
-            
+
             $this->userManager->updateUser($user);
 
             if (null === $response = $event->getResponse()) {

--- a/src/Action/ResetAction.php
+++ b/src/Action/ResetAction.php
@@ -95,6 +95,8 @@ final class ResetAction
             $event = new FormEvent($form, $request);
             $this->eventDispatcher->dispatch($event, NucleosUserEvents::RESETTING_RESET_SUCCESS);
 
+            $user->setPlainPassword($form->getData()->getPlainPassword());
+            
             $this->userManager->updateUser($user);
 
             if (null === $response = $event->getResponse()) {

--- a/src/Action/ResetAction.php
+++ b/src/Action/ResetAction.php
@@ -96,7 +96,7 @@ final class ResetAction
             $this->eventDispatcher->dispatch($event, NucleosUserEvents::RESETTING_RESET_SUCCESS);
 
             $user->setPlainPassword($form->getData()->getPlainPassword());
-            
+
             $this->userManager->updateUser($user);
 
             if (null === $response = $event->getResponse()) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #

## Subject

<!-- Describe your Pull Request content here -->
Change password and reset password from website aren't work.
Test the change password from command, it works.
Then, I realized that the command has this:
`$user->setPlainPassword($password);`

But reset and change password action didn't have.
