### PR TITLE
Add setPlainPassword() before update user

### DIFF
--- a/src/Action/ChangePasswordAction.php
+++ b/src/Action/ChangePasswordAction.php
@@ -95,7 +95,7 @@ final class ChangePasswordAction
             return $event->getResponse();
         }
 
-        $form = $this->formFactory->create(ChangePasswordFormType::class, new ChangePassword(), [
+        $form = $this->formFactory->create(ChangePasswordFormType::class, $formModel = new ChangePassword(), [
             'validation_groups' => ['ChangePassword', 'Default'],
         ]);
 
@@ -104,6 +104,8 @@ final class ChangePasswordAction
         if ($form->isSubmitted() && $form->isValid()) {
             $event = new FormEvent($form, $request);
             $this->eventDispatcher->dispatch($event, NucleosUserEvents::CHANGE_PASSWORD_SUCCESS);
+
+            $user->setPlainPassword($formModel->getPlainPassword());
 
             $this->userManager->updateUser($user);
 

--- a/src/Action/ResetAction.php
+++ b/src/Action/ResetAction.php
@@ -85,7 +85,7 @@ final class ResetAction
             return $event->getResponse();
         }
 
-        $form = $this->formFactory->create(ResettingFormType::class, new Resetting($user), [
+        $form = $this->formFactory->create(ResettingFormType::class, $formModel = new Resetting($user), [
             'validation_groups' => ['ResetPassword', 'Default'],
         ]);
 
@@ -94,6 +94,8 @@ final class ResetAction
         if ($form->isSubmitted() && $form->isValid()) {
             $event = new FormEvent($form, $request);
             $this->eventDispatcher->dispatch($event, NucleosUserEvents::RESETTING_RESET_SUCCESS);
+
+            $user->setPlainPassword($formModel->getPlainPassword());
 
             $this->userManager->updateUser($user);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #91 

## Subject

<!-- Describe your Pull Request content here -->
Change password and reset password from website aren't work.
Test the change password from command, it works.
Then, I realized that the command has this:
`$user->setPlainPassword($password);`

But reset and change password action didn't have.
