### PR TITLE
Fix registering user checker

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -190,6 +190,7 @@ in your application:
         firewalls:
             main:
                 pattern: ^/
+                user_checker: Nucleos\UserBundle\Security\UserChecker
                 form_login:
                     provider: nucleos_userbundle
                     csrf_token_generator: security.csrf.token_manager

--- a/src/Resources/config/security.php
+++ b/src/Resources/config/security.php
@@ -21,6 +21,7 @@ use Nucleos\UserBundle\Security\EmailProvider;
 use Nucleos\UserBundle\Security\EmailUserProvider;
 use Nucleos\UserBundle\Security\LoginManager;
 use Nucleos\UserBundle\Security\LoginManagerInterface;
+use Nucleos\UserBundle\Security\UserChecker;
 use Nucleos\UserBundle\Security\UserProvider;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -88,6 +89,8 @@ return static function (ContainerConfigurator $container): void {
 
         ->set(CheckLoginAction::class)
             ->public()
+
+        ->set(UserChecker::class)
 
     ;
 };

--- a/src/Security/UserChecker.php
+++ b/src/Security/UserChecker.php
@@ -18,10 +18,10 @@ use Symfony\Component\Security\Core\Exception\AccountExpiredException;
 use Symfony\Component\Security\Core\Exception\CredentialsExpiredException;
 use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\Exception\LockedException;
-use Symfony\Component\Security\Core\User\UserChecker as BaseUserChecker;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface as BaseUserInterface;
 
-final class UserChecker extends BaseUserChecker
+final class UserChecker implements UserCheckerInterface
 {
     public function checkPreAuth(BaseUserInterface $user): void
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

This is a security fix. The default checker does not check for blocked account if you did not implement the `AdvancedUserInterface` interface.
