### PR TITLE
Declare translation_domain in configureOptions.

### DIFF
--- a/src/Form/Type/ResettingFormType.php
+++ b/src/Form/Type/ResettingFormType.php
@@ -41,7 +41,6 @@ final class ResettingFormType extends AbstractType
             ->add('plainPassword', RepeatedType::class, [
                 'type'    => PasswordType::class,
                 'options' => [
-                    'translation_domain' => 'NucleosUserBundle',
                     'attr'               => [
                         'autocomplete' => 'new-password',
                     ],
@@ -59,8 +58,9 @@ final class ResettingFormType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'data_class'    => $this->class,
-            'csrf_token_id' => 'resetting',
+            'data_class'         => $this->class,
+            'csrf_token_id'      => 'resetting',
+            'translation_domain' => 'NucleosUserBundle',
         ]);
     }
 }


### PR DESCRIPTION
Currently the `save` field of `ResettingFormType` has no `translation_domain`, and results like this:

<img width="588" alt="Capture d’écran 2021-03-29 à 11 32 25" src="https://user-images.githubusercontent.com/1162230/112817328-997a2800-9082-11eb-978c-3d82181f8572.png">

A workaround is to do this in Twig template:

```twig
{{ form_widget(form.save, { translation_domain: 'NucleosUserBundle' }) }}
```
