### PR TITLE
Typo deletion configuration

### DIFF
--- a/docs/deletion.rst
+++ b/docs/deletion.rst
@@ -14,7 +14,7 @@ The feature is disabled by default. You can enable it by using the following con
     nucleos_user:
         # ...
         deletion:
-            enable: true
+            enabled: true
 
 Add the routing config:
 


### PR DESCRIPTION
The deletion configuration should be `enabled: true` instead of `enable: true`

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}

## Subject

<!-- Describe your Pull Request content here -->
