### PR TITLE
PatternValidator ignores null values and does not throw an exception anymore

### DIFF
--- a/src/Validator/Constraints/PatternValidator.php
+++ b/src/Validator/Constraints/PatternValidator.php
@@ -25,7 +25,11 @@ final class PatternValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, Pattern::class);
         }
 
-        if (null === $value || !\is_string($value)) {
+        if (null === $value) {
+            return;
+        }
+
+        if (!\is_string($value)) {
             throw new UnexpectedTypeException($value, 'string');
         }
 


### PR DESCRIPTION
Closes #396

## Subject

When using `PatternValidator` with a `RepeaterType` and the values are not the same the value will be null; but you do not want to throw an exception.

Changing the `PatternValidator` to return instead of throwing an exception when the value is null solves the issue #396.

_I also created a test but I can not get the test suite to run successfully; lots of **other** tests fail_