### PR TITLE
Replace the legacy password encoder security component

### DIFF
--- a/src/Model/UserInterface.php
+++ b/src/Model/UserInterface.php
@@ -16,9 +16,10 @@ namespace Nucleos\UserBundle\Model;
 use DateTime;
 use Serializable;
 use Symfony\Component\Security\Core\User\EquatableInterface;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface as BaseUserInterface;
 
-interface UserInterface extends BaseUserInterface, EquatableInterface, Serializable
+interface UserInterface extends PasswordAuthenticatedUserInterface, BaseUserInterface, EquatableInterface, Serializable
 {
     public const ROLE_DEFAULT = 'ROLE_USER';
 

--- a/src/Resources/config/util.php
+++ b/src/Resources/config/util.php
@@ -39,7 +39,7 @@ return static function (ContainerConfigurator $container): void {
 
         ->set('nucleos_user.util.password_updater', PasswordUpdater::class)
             ->args([
-                new Reference('security.encoder_factory'),
+                new Reference('security.password_hasher_factory'),
             ])
 
         ->alias(PasswordUpdaterInterface::class, 'nucleos_user.util.password_updater')

--- a/tests/Fixtures/SaltedPasswordHasher.php
+++ b/tests/Fixtures/SaltedPasswordHasher.php
@@ -13,9 +13,8 @@ declare(strict_types=1);
 
 namespace Nucleos\UserBundle\Tests\Fixtures;
 
-use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
-use Symfony\Component\Security\Core\Encoder\SelfSaltingEncoderInterface;
+use Symfony\Component\PasswordHasher\LegacyPasswordHasherInterface;
 
-interface SelfSaltedEncoder extends PasswordEncoderInterface, SelfSaltingEncoderInterface
+interface SaltedPasswordHasher extends LegacyPasswordHasherInterface
 {
 }


### PR DESCRIPTION
## Replace the Security password encoder component by the new PasswordHasher component

Since Symfony 5.3, the Security encoder component has been deprecated and replaced by an independent PasswordHasher component. In Symfony 6.0, the encoder component will be removed. The pull request updates the bundle with the necessary changes.

It cannot be pulled as is in the 1.12.x branch because it's a breaking change with Symfony 4.4 so I don't know for sure where it would be convenient to merge. Maybe in a separate major version for Symfony 6.0?