### PR TITLE
Prevent account detection

### DIFF
--- a/src/Action/RequestResetAction.php
+++ b/src/Action/RequestResetAction.php
@@ -104,6 +104,10 @@ final class RequestResetAction
     {
         $username = (string) $request->request->get('username', '');
 
+        if ('' === trim($username)) {
+            return null;
+        }
+
         $user = null;
 
         try {
@@ -112,7 +116,7 @@ final class RequestResetAction
         }
 
         if (!$user instanceof UserInterface) {
-            return null;
+            return new RedirectResponse($this->router->generate('nucleos_user_resetting_check_email'));
         }
 
         $event = new GetResponseNullableUserEvent($user, $request);
@@ -123,7 +127,7 @@ final class RequestResetAction
         }
 
         if ($user->isPasswordRequestNonExpired($this->retryTtl)) {
-            return null;
+            return new RedirectResponse($this->router->generate('nucleos_user_resetting_check_email'));
         }
 
         $event = new GetResponseUserEvent($user, $request);
@@ -155,8 +159,6 @@ final class RequestResetAction
             return $event->getResponse();
         }
 
-        return new RedirectResponse($this->router->generate('nucleos_user_resetting_check_email', [
-            'username' => $username,
-        ]));
+        return new RedirectResponse($this->router->generate('nucleos_user_resetting_check_email'));
     }
 }

--- a/src/Resources/translations/NucleosUserBundle.de.xlf
+++ b/src/Resources/translations/NucleosUserBundle.de.xlf
@@ -35,7 +35,7 @@
       </trans-unit>
       <trans-unit id="resetting.check_email">
         <source>resetting.check_email</source>
-        <target><![CDATA[Eine E-Mail wurde verschickt. Sie beinhaltet einen Link zum Zurücksetzen des Passwortes.
+        <target><![CDATA[Eine E-Mail wurde verschickt, falls wir ein Konto finden konnten. Sie beinhaltet einen Link zum Zurücksetzen des Passwortes.
 Hinweis: Ein neues Passwort kann nur alle %tokenLifetime% Stunden beantragt werden.
 
 Eventuell wurde diese E-Mail als Spam markiert, wenn sie nicht angekommen ist.]]></target>

--- a/src/Resources/translations/NucleosUserBundle.en.xlf
+++ b/src/Resources/translations/NucleosUserBundle.en.xlf
@@ -35,7 +35,7 @@
       </trans-unit>
       <trans-unit id="resetting.check_email">
         <source>resetting.check_email</source>
-        <target><![CDATA[An email has been sent. It contains a link you must click to reset your password.
+        <target><![CDATA[An email has been sent if we could find you. It contains a link you must click to reset your password.
 Note: You can only request a new password once within %tokenLifetime% hours.
 
 If you don't get an email check your spam folder or try again.]]></target>


### PR DESCRIPTION
Do not expose information if the account / e-mail could be found. This prevents account sniffing.