### PR TITLE
Fix login form uses getMessage() instead of getMessageKey()

### DIFF
--- a/src/Form/Type/LoginFormType.php
+++ b/src/Form/Type/LoginFormType.php
@@ -64,7 +64,7 @@ final class LoginFormType extends AbstractType
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($authenticationUtils): void {
             $error = $authenticationUtils->getLastAuthenticationError();
             if (null !== $error) {
-                $message = $error->getMessage();
+                $message = $error->getMessageKey();
                 if (null !== $this->translator) {
                     $message = $this->translator->trans($message, [], 'NucleosUserBundle');
                 }


### PR DESCRIPTION
Closes #725

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Subject

Replaces `getMessage()` with `getMessageKey()` for an `AuthenticationException` as described in #725 
