### PR TITLE
Fix roles doctrine type mapping

### DIFF
--- a/src/Resources/config/doctrine-mapping/Group.orm.xml
+++ b/src/Resources/config/doctrine-mapping/Group.orm.xml
@@ -2,6 +2,6 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping                   http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
   <mapped-superclass name="Nucleos\UserBundle\Model\Group">
     <field name="name" column="name" type="string" length="180" unique="true"/>
-    <field name="roles" column="roles" type="array"/>
+    <field name="roles" column="roles" type="json"/>
   </mapped-superclass>
 </doctrine-mapping>

--- a/src/Resources/config/doctrine-mapping/User.orm.xml
+++ b/src/Resources/config/doctrine-mapping/User.orm.xml
@@ -10,6 +10,6 @@
     <field name="passwordRequestedAt" column="password_requested_at" type="datetime" nullable="true"/>
     <field name="locale" type="string" column="locale" length="8" nullable="true"/>
     <field name="timezone" type="string" column="timezone" length="64" nullable="true"/>
-    <field name="roles" column="roles" type="array"/>
+    <field name="roles" column="roles" type="json"/>
   </mapped-superclass>
 </doctrine-mapping>


### PR DESCRIPTION
According to the doctrine docs, the array type is [deprecated](https://www.doctrine-project.org/projects/doctrine-dbal/en/current/reference/types.html) and should not be used. 

As the array was encoded using `json_decode` / `json_encode` (e.g. `a:0:{}`), the json type might be the correct one.