### PR TITLE
Reset passwordRequestedAt on plain password change to trigger doctrine listener

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -201,7 +201,8 @@ abstract class User implements UserInterface, GroupAwareUser, LocaleAwareUser
 
     public function setPlainPassword(?string $password): void
     {
-        $this->plainPassword = $password;
+        $this->plainPassword       = $password;
+        $this->passwordRequestedAt = null;
     }
 
     public function setLastLogin(DateTime $time = null): void


### PR DESCRIPTION
## Subject

Due to some recent changes in doctrine, the entity was not persisted when just changed an unmapped field (plain password). 

This is a hotfix to trigger the doctrine listeners if the plain password changes.