### PR TITLE
Remove redundant paragonie/random_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
         "doctrine/common": "^3.0",
         "doctrine/event-manager": "^1.2 || ^2.0",
         "doctrine/persistence": "^4.0",
-        "paragonie/random_compat": "^1 || ^2 || ^9",
         "symfony/config": "^7.4 || ^8.0",
         "symfony/console": "^7.4 || ^8.0",
         "symfony/dependency-injection": "^7.4 || ^8.0",


### PR DESCRIPTION
This package depends on `paragonie/random_compat: ^1 || ^2 || ^9`, but also `php: ^8.3`. Since `random_bytes` and `random_int` were added in PHP 7.0, the dependency on `paragonie/random_compat` seems redundant?